### PR TITLE
Add Whisper-based audio transcription

### DIFF
--- a/gen-ai-playground/backend/app/config.py
+++ b/gen-ai-playground/backend/app/config.py
@@ -52,6 +52,4 @@ class Settings:
         "FLUX2_KLEIN_4B": "https://inference.datacrunch.io/flux2-klein-4b/generate"
     }
 
-
-
 settings = Settings()

--- a/gen-ai-playground/backend/app/config.py
+++ b/gen-ai-playground/backend/app/config.py
@@ -52,4 +52,7 @@ class Settings:
         "FLUX2_KLEIN_4B": "https://inference.datacrunch.io/flux2-klein-4b/generate"
     }
 
+    # Audio
+    MAX_AUDIO_UPLOAD_MB: int = int(os.getenv("MAX_UPLOAD_MB", "50"))
+
 settings = Settings()

--- a/gen-ai-playground/backend/app/config.py
+++ b/gen-ai-playground/backend/app/config.py
@@ -53,6 +53,6 @@ class Settings:
     }
 
     # Audio
-    MAX_AUDIO_UPLOAD_MB: int = int(os.getenv("MAX_UPLOAD_MB", "50"))
+    MAX_AUDIO_UPLOAD_MB: int = int(os.getenv("MAX_AUDIO_UPLOAD_MB", os.getenv("MAX_UPLOAD_MB", "50")))
 
 settings = Settings()

--- a/gen-ai-playground/backend/app/models.py
+++ b/gen-ai-playground/backend/app/models.py
@@ -220,3 +220,25 @@ class HistoryResponseText(BaseModel):
     total: int
     page: int
     total_pages: int
+
+
+class HistoryItemAudio(BaseModel):
+    type: str
+    transcription_text: str
+    model: str
+    timestamp: datetime
+    username: str
+    run_id: Optional[str] = None
+    input_name: Optional[str] = None
+    language: Optional[str] = None
+    duration: Optional[float] = None
+    transcription_time_ms: Optional[int] = None
+    source: Optional[str] = None
+
+
+class HistoryResponseAudio(BaseModel):
+    """Response model for audio transcription history endpoint"""
+    history: List[HistoryItemAudio]
+    total: int
+    page: int
+    total_pages: int

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -460,6 +460,7 @@ async def transcribe_audio(
 def get_audio_history_sidebar(
     current_user: UserInfo = Depends(get_current_user),
     db: Database = Depends(get_database),
+    limit: int = Query(15, ge=1, le=200),
 ) -> dict[str, list[dict[str, Any]]]:
     records = list(
         db.audio_transcriptions.find(
@@ -478,7 +479,9 @@ def get_audio_history_sidebar(
                 "transcription_time_ms": 1,
                 "source": 1,
             },
-        ).sort("timestamp", -1)
+        )
+        .sort("timestamp", -1)
+        .limit(limit)
     )
 
     return {"history": records}

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -1,14 +1,20 @@
 """Audio transcription routes."""
 
+import math
 import os
-from typing import Any, BinaryIO
+import time
+from datetime import datetime, timezone
+from typing import Any, BinaryIO, Optional
 
 import httpx
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from pymongo.database import Database
+from pymongo.errors import PyMongoError
 
 from app.config import settings
+from app.database import get_database
 from app.dependencies import get_admin_user, get_current_user, validate_csrf_token
-from app.models import DeployModelRequest, DeploymentStatusResponse, UserInfo
+from app.models import DeployModelRequest, DeploymentStatusResponse, HistoryResponseAudio, UserInfo
 from app.template_discovery import _deployment_name_from_filename, get_audio_template_map
 from app.verda_service import verda_service
 
@@ -195,6 +201,41 @@ def _validate_upload_size(file: UploadFile) -> None:
         )
 
 
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_whisper_model_identifier(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    if cleaned.lower().startswith("openai/"):
+        return cleaned.split("/", 1)[1]
+
+    return cleaned
+
+
+def _resolve_audio_history_model_label(
+    requested_model: str | None,
+    result_model: Any,
+    deployment_name: str,
+) -> str:
+    for candidate in (requested_model, result_model, deployment_name):
+        normalized = _normalize_whisper_model_identifier(candidate)
+        if normalized:
+            return normalized
+    return "unknown"
+
+
 @router.get("/models")
 def list_available_audio_models(_current_user: UserInfo = Depends(get_current_user)):
     """List audio model templates available for deployment."""
@@ -324,10 +365,13 @@ async def transcribe_audio(
     file: UploadFile = File(...),
     model_path: str | None = Form(None),
     language: str | None = Form(None),
+    source: str | None = Form(None),
+    run_id: str | None = Form(None),
     task: str = Form("transcribe"),
     beam_size: int = Form(5),
     vad_filter: bool = Form(True),
     current_user: UserInfo = Depends(get_current_user),
+    db: Database = Depends(get_database),
     _: None = Depends(validate_csrf_token),
 ) -> dict[str, Any]:
     """Proxy file transcription to a selected deployed Verda audio container."""
@@ -335,6 +379,8 @@ async def transcribe_audio(
         raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
 
     deployment_name, endpoint_url = _resolve_audio_endpoint(model_path=model_path, require_healthy=True)
+    normalized_source = source if source in {"uploaded", "recording"} else source
+    normalized_run_id = (run_id or "").strip()[:128] or None
 
     print(
         "Audio transcription requested by user: "
@@ -350,8 +396,9 @@ async def transcribe_audio(
     if language:
         form_data["language"] = language
 
+    started_at = time.perf_counter()
     try:
-        return await _post_with_fallback_paths(
+        result = await _post_with_fallback_paths(
             endpoint_url,
             ["transcribe", "predict", ""],
             form_data,
@@ -359,6 +406,45 @@ async def transcribe_audio(
             file.filename or "audio.bin",
             file.content_type or "application/octet-stream",
         )
+
+        elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+        transcription_time_ms = _safe_int(result.get("transcription_time_ms"))
+        if transcription_time_ms is None:
+            transcription_time_ms = elapsed_ms
+
+        normalized_result_model = _normalize_whisper_model_identifier(result.get("model"))
+        if normalized_result_model:
+            result["model"] = normalized_result_model
+
+        history_model_label = _resolve_audio_history_model_label(
+            requested_model=model_path,
+            result_model=result.get("model"),
+            deployment_name=deployment_name,
+        )
+
+        try:
+            input_name = (file.filename or "").strip() or None
+            if normalized_source == "recording":
+                input_name = None
+
+            history_record = {
+                "type": "transcription",
+                "transcription_text": result.get("text", ""),
+                "model": history_model_label,
+                "timestamp": datetime.utcnow(),
+                "username": current_user.username,
+                "run_id": normalized_run_id,
+                "input_name": input_name,
+                "language": result.get("language"),
+                "duration": result.get("duration"),
+                "transcription_time_ms": transcription_time_ms,
+                "source": normalized_source,
+            }
+            db.audio_transcriptions.insert_one(history_record)
+        except (PyMongoError, TypeError, ValueError) as exc:
+            print(f"Failed to save audio transcription to MongoDB: {exc}")
+
+        return result
     except httpx.HTTPStatusError as exc:
         try:
             payload = exc.response.json()
@@ -368,3 +454,92 @@ async def transcribe_audio(
         raise HTTPException(status_code=exc.response.status_code, detail=detail) from exc
     except httpx.RequestError as exc:
         raise HTTPException(status_code=503, detail=f"Whisper service unavailable: {exc}") from exc
+
+
+@router.get("/history-sidebar")
+def get_audio_history_sidebar(
+    current_user: UserInfo = Depends(get_current_user),
+    db: Database = Depends(get_database),
+) -> dict[str, list[dict[str, Any]]]:
+    records = list(
+        db.audio_transcriptions.find(
+            {"username": current_user.username},
+            {
+                "_id": 0,
+                "type": 1,
+                "transcription_text": 1,
+                "model": 1,
+                "timestamp": 1,
+                "username": 1,
+                "run_id": 1,
+                "input_name": 1,
+                "language": 1,
+                "duration": 1,
+                "transcription_time_ms": 1,
+                "source": 1,
+            },
+        ).sort("timestamp", -1)
+    )
+
+    return {"history": records}
+
+
+@router.get("/history", response_model=HistoryResponseAudio)
+def get_audio_history(
+    current_user: UserInfo = Depends(get_current_user),
+    db: Database = Depends(get_database),
+    from_date: Optional[int] = Query(None, alias="from"),
+    to_date: Optional[int] = Query(None, alias="to"),
+    page: int = Query(1, alias="page", ge=1),
+):
+    page_size = 10
+    query: dict[str, Any] = {"username": current_user.username}
+
+    if from_date or to_date:
+        date_filter: dict[str, datetime] = {}
+        if from_date:
+            date_filter["$gte"] = datetime.fromtimestamp(from_date / 1000, tz=timezone.utc)
+        if to_date:
+            date_filter["$lte"] = datetime.fromtimestamp(to_date / 1000, tz=timezone.utc)
+        query["timestamp"] = date_filter
+
+    total = db.audio_transcriptions.count_documents(query)
+    if total == 0:
+        return HistoryResponseAudio(history=[], total=0, page=page, total_pages=0)
+
+    total_pages = math.ceil(total / page_size)
+    page = min(page, total_pages)
+    start = (page - 1) * page_size
+
+    try:
+        history = list(
+            db.audio_transcriptions.find(
+                query,
+                {
+                    "_id": 0,
+                    "type": 1,
+                    "transcription_text": 1,
+                    "model": 1,
+                    "timestamp": 1,
+                    "username": 1,
+                    "run_id": 1,
+                    "input_name": 1,
+                    "language": 1,
+                    "duration": 1,
+                    "transcription_time_ms": 1,
+                    "source": 1,
+                },
+            )
+            .sort("timestamp", -1)
+            .skip(start)
+            .limit(page_size)
+        )
+
+        return HistoryResponseAudio(
+            history=history,
+            total=total,
+            page=page,
+            total_pages=total_pages,
+        )
+    except PyMongoError as exc:
+        raise HTTPException(status_code=500, detail=f"Error getting audio history: {exc}") from exc

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -30,8 +30,18 @@ def _audio_deployment_names() -> set[str]:
     }
 
 
-def _resolve_audio_endpoint(require_healthy: bool = True) -> tuple[str, str]:
+def _resolve_audio_endpoint(model_path: str | None = None, require_healthy: bool = True) -> tuple[str, str]:
     expected_names = _audio_deployment_names()
+    if model_path:
+        template_name = _resolve_audio_template_name(model_path)
+        if not template_name:
+            supported = list(get_audio_template_map().values())
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported audio model: {model_path}. Supported models: {supported}",
+            )
+        expected_names = {_deployment_name_from_filename(template_name)}
+
     deployments = verda_service.list_deployments()
 
     if not deployments or (len(deployments) == 1 and deployments[0].get("error")):
@@ -42,9 +52,13 @@ def _resolve_audio_endpoint(require_healthy: bool = True) -> tuple[str, str]:
 
     candidates = [d for d in deployments if d.get("name", "").lower() in expected_names]
     if not candidates:
+        requested_model_msg = f" for model '{model_path}'" if model_path else ""
         raise HTTPException(
             status_code=503,
-            detail="No deployed audio container found. Deploy a Whisper model from dashboard first.",
+            detail=(
+                f"No deployed audio container found{requested_model_msg}. "
+                "Deploy a Whisper model from dashboard first."
+            ),
         )
 
     for deployment in candidates:
@@ -62,9 +76,13 @@ def _resolve_audio_endpoint(require_healthy: bool = True) -> tuple[str, str]:
         return deployment_name, endpoint_url
 
     if require_healthy:
+        requested_model_msg = f" for model '{model_path}'" if model_path else ""
         raise HTTPException(
             status_code=503,
-            detail="Audio deployment exists but is not healthy yet. Please wait and try again.",
+            detail=(
+                f"Audio deployment exists{requested_model_msg} but is not healthy yet. "
+                "Please wait and try again."
+            ),
         )
 
     raise HTTPException(
@@ -149,6 +167,46 @@ def list_available_audio_models(_current_user: UserInfo = Depends(get_current_us
     return {"available_models": available_models}
 
 
+@router.get("/model-statuses")
+def get_audio_model_statuses(_current_user: UserInfo = Depends(get_current_user)) -> dict[str, str]:
+    """Return live/starting/offline status for each known audio model."""
+    template_map = get_audio_template_map()
+    statuses: dict[str, str] = {display_name: "offline" for display_name in template_map.values()}
+
+    try:
+        deployments = verda_service.list_deployments()
+    except RuntimeError:
+        return statuses
+
+    template_deployment_map = {
+        _deployment_name_from_filename(template_name): display_name
+        for template_name, display_name in template_map.items()
+    }
+
+    for deployment in deployments:
+        deployment_name = deployment.get("name")
+        if not deployment_name:
+            continue
+
+        display_name = template_deployment_map.get(deployment_name.lower())
+        if not display_name:
+            continue
+
+        try:
+            deployment_status = verda_service.get_deployment_status(deployment_name)
+            status_str = deployment_status.get("status")
+            if status_str == "healthy":
+                statuses[display_name] = "live"
+            elif status_str in {"error", "unknown", "no_deployment"}:
+                statuses[display_name] = "offline"
+            else:
+                statuses[display_name] = "starting"
+        except RuntimeError:
+            statuses[display_name] = "offline"
+
+    return statuses
+
+
 @router.post("/deploy", response_model=DeploymentStatusResponse)
 def deploy_audio_model(
     request: DeployModelRequest,
@@ -178,9 +236,9 @@ def deploy_audio_model(
 
 
 @router.get("/health")
-async def audio_health() -> dict[str, Any]:
-    """Health check against the active deployed Verda audio container."""
-    deployment_name, endpoint_url = _resolve_audio_endpoint(require_healthy=False)
+async def audio_health(model_path: str | None = None) -> dict[str, Any]:
+    """Health check against the selected (or first available) deployed audio container."""
+    deployment_name, endpoint_url = _resolve_audio_endpoint(model_path=model_path, require_healthy=False)
     deployment_status = verda_service.get_deployment_status(deployment_name)
 
     if deployment_status.get("status") != "healthy":
@@ -213,6 +271,7 @@ async def audio_health() -> dict[str, Any]:
 @router.post("/transcribe")
 async def transcribe_audio(
     file: UploadFile = File(...),
+    model_path: str | None = Form(None),
     language: str | None = Form(None),
     task: str = Form("transcribe"),
     beam_size: int = Form(5),
@@ -220,13 +279,16 @@ async def transcribe_audio(
     current_user: UserInfo = Depends(get_current_user),
     _: None = Depends(validate_csrf_token),
 ) -> dict[str, Any]:
-    """Proxy file transcription to the active deployed Verda audio container."""
+    """Proxy file transcription to a selected deployed Verda audio container."""
     if task not in {"transcribe", "translate"}:
         raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
 
-    deployment_name, endpoint_url = _resolve_audio_endpoint(require_healthy=True)
+    deployment_name, endpoint_url = _resolve_audio_endpoint(model_path=model_path, require_healthy=True)
 
-    print(f"Audio transcription requested by user: {current_user.username} (deployment: {deployment_name})")
+    print(
+        "Audio transcription requested by user: "
+        f"{current_user.username} (deployment: {deployment_name}, model_path: {model_path})"
+    )
     file_bytes = await file.read()
 
     files = {

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -1,6 +1,7 @@
 """Audio transcription routes."""
 
-from typing import Any
+import os
+from typing import Any, BinaryIO
 
 import httpx
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
@@ -8,12 +9,14 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from app.config import settings
 from app.dependencies import get_admin_user, get_current_user, validate_csrf_token
 from app.models import DeployModelRequest, DeploymentStatusResponse, UserInfo
-from app.template_discovery import get_audio_template_map, _deployment_name_from_filename
+from app.template_discovery import _deployment_name_from_filename, get_audio_template_map
 from app.verda_service import verda_service
 
 
 router = APIRouter(prefix="/audio", tags=["audio"])
 WHISPER_TIMEOUT_SECONDS = 300.0
+MAX_AUDIO_UPLOAD_MB = settings.MAX_AUDIO_UPLOAD_MB
+MAX_AUDIO_UPLOAD_BYTES = MAX_AUDIO_UPLOAD_MB * 1024 * 1024
 
 
 def _inference_headers() -> dict[str, str]:
@@ -61,33 +64,40 @@ def _resolve_audio_endpoint(model_path: str | None = None, require_healthy: bool
             ),
         )
 
+    fallback_candidate: tuple[str, str] | None = None
+
     for deployment in candidates:
         deployment_name = deployment.get("name")
         endpoint_url = str(deployment.get("endpoint_url", "")).rstrip("/")
         if not deployment_name or not endpoint_url:
             continue
 
-        if require_healthy:
+        status_str = None
+        try:
             status_payload = verda_service.get_deployment_status(deployment_name)
             status_str = status_payload.get("status")
-            if status_str != "healthy":
-                continue
+        except RuntimeError:
+            status_str = None
 
-        return deployment_name, endpoint_url
+        if status_str == "healthy":
+            return deployment_name, endpoint_url
 
-    if require_healthy:
-        requested_model_msg = f" for model '{model_path}'" if model_path else ""
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                f"Audio deployment exists{requested_model_msg} but is not healthy yet. "
-                "Please wait and try again."
-            ),
-        )
+        if fallback_candidate is None:
+            fallback_candidate = (deployment_name, endpoint_url)
 
+        if require_healthy:
+            continue
+
+    if not require_healthy and fallback_candidate:
+        return fallback_candidate
+
+    requested_model_msg = f" for model '{model_path}'" if model_path else ""
     raise HTTPException(
         status_code=503,
-        detail="Audio deployment found but endpoint is unavailable.",
+        detail=(
+            f"Audio deployment exists{requested_model_msg} but is not healthy yet. "
+            "Please wait and try again."
+        ),
     )
 
 
@@ -127,12 +137,23 @@ async def _post_with_fallback_paths(
     base_url: str,
     paths: list[str],
     data: dict[str, str],
-    files: dict[str, tuple[str, bytes, str]],
+    file_obj: BinaryIO,
+    file_name: str,
+    file_content_type: str,
 ) -> dict[str, Any]:
     tried: list[str] = []
     headers = _inference_headers()
     async with httpx.AsyncClient(timeout=WHISPER_TIMEOUT_SECONDS) as client:
         for path in paths:
+            file_obj.seek(0, os.SEEK_SET)
+            files = {
+                "file": (
+                    file_name,
+                    file_obj,
+                    file_content_type,
+                )
+            }
+
             url = _whisper_url(base_url, path)
             tried.append(url)
             response = await client.post(url, data=data, files=files, headers=headers)
@@ -158,6 +179,20 @@ def _resolve_audio_template_name(model: str) -> str | None:
         if display_name == model:
             return template_name
     return None
+
+
+def _validate_upload_size(file: UploadFile) -> None:
+    file_obj = file.file
+    current_pos = file_obj.tell()
+    file_obj.seek(0, os.SEEK_END)
+    size_bytes = file_obj.tell()
+    file_obj.seek(current_pos, os.SEEK_SET)
+
+    if size_bytes > MAX_AUDIO_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Max size is {MAX_AUDIO_UPLOAD_MB} MB",
+        )
 
 
 @router.get("/models")
@@ -236,10 +271,26 @@ def deploy_audio_model(
 
 
 @router.get("/health")
-async def audio_health(model_path: str | None = None) -> dict[str, Any]:
+async def audio_health(
+    model_path: str | None = None,
+    _current_user: UserInfo = Depends(get_current_user),
+) -> dict[str, Any]:
     """Health check against the selected (or first available) deployed audio container."""
     deployment_name, endpoint_url = _resolve_audio_endpoint(model_path=model_path, require_healthy=False)
-    deployment_status = verda_service.get_deployment_status(deployment_name)
+    try:
+        deployment_status = verda_service.get_deployment_status(deployment_name)
+    except RuntimeError:
+        return {
+            "status": "ok",
+            "deployment": {
+                "name": deployment_name,
+                "status": "unknown",
+            },
+            "whisper": {
+                "status": "unavailable",
+                "detail": "Unable to fetch deployment status from Verda.",
+            },
+        }
 
     if deployment_status.get("status") != "healthy":
         return {
@@ -289,15 +340,8 @@ async def transcribe_audio(
         "Audio transcription requested by user: "
         f"{current_user.username} (deployment: {deployment_name}, model_path: {model_path})"
     )
-    file_bytes = await file.read()
+    _validate_upload_size(file)
 
-    files = {
-        "file": (
-            file.filename or "audio.bin",
-            file_bytes,
-            file.content_type or "application/octet-stream",
-        )
-    }
     form_data: dict[str, str] = {
         "task": task,
         "beam_size": str(beam_size),
@@ -311,7 +355,9 @@ async def transcribe_audio(
             endpoint_url,
             ["transcribe", "predict", ""],
             form_data,
-            files,
+            file.file,
+            file.filename or "audio.bin",
+            file.content_type or "application/octet-stream",
         )
     except httpx.HTTPStatusError as exc:
         try:

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -1,0 +1,262 @@
+"""Audio transcription routes."""
+
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+
+from app.config import settings
+from app.dependencies import get_admin_user, get_current_user, validate_csrf_token
+from app.models import DeployModelRequest, DeploymentStatusResponse, UserInfo
+from app.template_discovery import get_audio_template_map, _deployment_name_from_filename
+from app.verda_service import verda_service
+
+
+router = APIRouter(prefix="/audio", tags=["audio"])
+WHISPER_TIMEOUT_SECONDS = 300.0
+
+
+def _inference_headers() -> dict[str, str]:
+    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _audio_deployment_names() -> set[str]:
+    return {
+        _deployment_name_from_filename(template_name)
+        for template_name in get_audio_template_map().keys()
+    }
+
+
+def _resolve_audio_endpoint(require_healthy: bool = True) -> tuple[str, str]:
+    expected_names = _audio_deployment_names()
+    deployments = verda_service.list_deployments()
+
+    if not deployments or (len(deployments) == 1 and deployments[0].get("error")):
+        raise HTTPException(
+            status_code=503,
+            detail="No Verda deployments found for audio. Deploy a Whisper container from dashboard first.",
+        )
+
+    candidates = [d for d in deployments if d.get("name", "").lower() in expected_names]
+    if not candidates:
+        raise HTTPException(
+            status_code=503,
+            detail="No deployed audio container found. Deploy a Whisper model from dashboard first.",
+        )
+
+    for deployment in candidates:
+        deployment_name = deployment.get("name")
+        endpoint_url = str(deployment.get("endpoint_url", "")).rstrip("/")
+        if not deployment_name or not endpoint_url:
+            continue
+
+        if require_healthy:
+            status_payload = verda_service.get_deployment_status(deployment_name)
+            status_str = status_payload.get("status")
+            if status_str != "healthy":
+                continue
+
+        return deployment_name, endpoint_url
+
+    if require_healthy:
+        raise HTTPException(
+            status_code=503,
+            detail="Audio deployment exists but is not healthy yet. Please wait and try again.",
+        )
+
+    raise HTTPException(
+        status_code=503,
+        detail="Audio deployment found but endpoint is unavailable.",
+    )
+
+
+def _whisper_url(base_url: str, path: str) -> str:
+    base = base_url.rstrip("/")
+    if not path:
+        return base
+    suffix = path if path.startswith("/") else f"/{path}"
+    return f"{base}{suffix}"
+
+
+async def _get_with_fallback_paths(base_url: str, paths: list[str]) -> dict[str, Any]:
+    tried: list[str] = []
+    headers = _inference_headers()
+    async with httpx.AsyncClient(timeout=WHISPER_TIMEOUT_SECONDS) as client:
+        for path in paths:
+            url = _whisper_url(base_url, path)
+            tried.append(url)
+            response = await client.get(url, headers=headers)
+
+            if response.status_code == 404:
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "message": "Whisper health endpoint was not found on deployed container.",
+            "tried_urls": tried,
+        },
+    )
+
+
+async def _post_with_fallback_paths(
+    base_url: str,
+    paths: list[str],
+    data: dict[str, str],
+    files: dict[str, tuple[str, bytes, str]],
+) -> dict[str, Any]:
+    tried: list[str] = []
+    headers = _inference_headers()
+    async with httpx.AsyncClient(timeout=WHISPER_TIMEOUT_SECONDS) as client:
+        for path in paths:
+            url = _whisper_url(base_url, path)
+            tried.append(url)
+            response = await client.post(url, data=data, files=files, headers=headers)
+
+            if response.status_code == 404:
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "message": "Whisper transcribe endpoint was not found on deployed container.",
+            "tried_urls": tried,
+        },
+    )
+
+
+def _resolve_audio_template_name(model: str) -> str | None:
+    model = model.strip()
+    for template_name, display_name in get_audio_template_map().items():
+        if display_name == model:
+            return template_name
+    return None
+
+
+@router.get("/models")
+def list_available_audio_models(_current_user: UserInfo = Depends(get_current_user)):
+    """List audio model templates available for deployment."""
+    available_models = verda_service.available_models(get_audio_template_map())
+    return {"available_models": available_models}
+
+
+@router.post("/deploy", response_model=DeploymentStatusResponse)
+def deploy_audio_model(
+    request: DeployModelRequest,
+    current_user: UserInfo = Depends(get_admin_user),
+    _: None = Depends(validate_csrf_token),
+):
+    """Deploy an audio transcription model template on Verda."""
+    print(f"User {current_user.username} requesting audio model deployment: {request.model_path}")
+    template = _resolve_audio_template_name(request.model_path)
+    if not template:
+        supported = list(get_audio_template_map().values())
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported audio model: {request.model_path}. Supported models: {supported}",
+        )
+
+    try:
+        result = verda_service.deploy_from_template(
+            template_json=template,
+            deployment_name=request.deployment_name,
+        )
+        return DeploymentStatusResponse(**result)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to deploy audio model: {exc}") from exc
+
+
+@router.get("/health")
+async def audio_health() -> dict[str, Any]:
+    """Health check against the active deployed Verda audio container."""
+    deployment_name, endpoint_url = _resolve_audio_endpoint(require_healthy=False)
+    deployment_status = verda_service.get_deployment_status(deployment_name)
+
+    if deployment_status.get("status") != "healthy":
+        return {
+            "status": "ok",
+            "deployment": deployment_status,
+            "whisper": {
+                "status": "unavailable",
+                "detail": "Deployment is not healthy yet.",
+            },
+        }
+
+    try:
+        whisper_payload = await _get_with_fallback_paths(
+            endpoint_url,
+            ["health", ""],
+        )
+        return {
+            "status": "ok",
+            "deployment": deployment_status,
+            "whisper": whisper_payload,
+        }
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.text or "Whisper health check failed"
+        raise HTTPException(status_code=503, detail=detail) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=503, detail=f"Whisper service unavailable: {exc}") from exc
+
+
+@router.post("/transcribe")
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    language: str | None = Form(None),
+    task: str = Form("transcribe"),
+    beam_size: int = Form(5),
+    vad_filter: bool = Form(True),
+    current_user: UserInfo = Depends(get_current_user),
+    _: None = Depends(validate_csrf_token),
+) -> dict[str, Any]:
+    """Proxy file transcription to the active deployed Verda audio container."""
+    if task not in {"transcribe", "translate"}:
+        raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
+
+    deployment_name, endpoint_url = _resolve_audio_endpoint(require_healthy=True)
+
+    print(f"Audio transcription requested by user: {current_user.username} (deployment: {deployment_name})")
+    file_bytes = await file.read()
+
+    files = {
+        "file": (
+            file.filename or "audio.bin",
+            file_bytes,
+            file.content_type or "application/octet-stream",
+        )
+    }
+    form_data: dict[str, str] = {
+        "task": task,
+        "beam_size": str(beam_size),
+        "vad_filter": "true" if vad_filter else "false",
+    }
+    if language:
+        form_data["language"] = language
+
+    try:
+        return await _post_with_fallback_paths(
+            endpoint_url,
+            ["transcribe", "predict", ""],
+            form_data,
+            files,
+        )
+    except httpx.HTTPStatusError as exc:
+        try:
+            payload = exc.response.json()
+            detail = payload.get("detail", payload)
+        except ValueError:
+            detail = exc.response.text or "Whisper transcription failed"
+        raise HTTPException(status_code=exc.response.status_code, detail=detail) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=503, detail=f"Whisper service unavailable: {exc}") from exc

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -210,6 +210,17 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _normalize_transcription_source(source: str | None) -> str | None:
+    if not isinstance(source, str):
+        return None
+
+    normalized = source.strip().lower()
+    if normalized in {"uploaded", "recording"}:
+        return normalized
+
+    return None
+
+
 def _normalize_whisper_model_identifier(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -379,7 +390,7 @@ async def transcribe_audio(
         raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
 
     deployment_name, endpoint_url = _resolve_audio_endpoint(model_path=model_path, require_healthy=True)
-    normalized_source = source if source in {"uploaded", "recording"} else source
+    normalized_source = _normalize_transcription_source(source)
     normalized_run_id = (run_id or "").strip()[:128] or None
 
     print(

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -8,6 +8,7 @@ Display names are derived from filenames: strip .json, capitalize first letter.
 Deployment names use the same stem in lowercase.
 """
 import json
+from collections.abc import Callable
 from pathlib import Path
 from app.template_models import TemplateConfig
 
@@ -52,6 +53,38 @@ def _raise_duplicate_display_names(duplicates: list[tuple[str, str, str]]) -> No
     raise ValueError(f"Duplicate template display_name values found: {details}")
 
 
+def _discover_templates_with_predicate(should_include: Callable[[str], bool]) -> dict[str, str]:
+    """Shared discovery pipeline for template scans with filename-level filtering."""
+    result: dict[str, str] = {}
+    seen_display_names: dict[str, str] = {}
+    duplicate_display_names: list[tuple[str, str, str]] = []
+    if not TEMPLATES_DIR.is_dir():
+        return result
+
+    for path in sorted(TEMPLATES_DIR.glob("*.json")):
+        if path.name in _SKIP_TEMPLATES:
+            continue
+        if not should_include(path.name):
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            TemplateConfig(**data)
+            display_name = _display_name_from_template(path.name, data)
+            normalized_display_name = display_name.strip().lower()
+            existing_file = seen_display_names.get(normalized_display_name)
+            if existing_file:
+                duplicate_display_names.append((display_name, existing_file, path.name))
+                continue
+            seen_display_names[normalized_display_name] = path.name
+            result[path.name] = display_name
+        except Exception as exc:
+            print(f"Skipping invalid template '{path.name}': {exc}")
+            continue
+
+    _raise_duplicate_display_names(duplicate_display_names)
+    return result
+
+
 def discover_templates(include_audio: bool = False) -> dict[str, str]:
     """
     Scan TEMPLATES_DIR for *.json, validate each, return {filename: display_name}.
@@ -60,35 +93,9 @@ def discover_templates(include_audio: bool = False) -> dict[str, str]:
     Args:
         include_audio: If False, exclude audio/whisper templates.
     """
-    result: dict[str, str] = {}
-    seen_display_names: dict[str, str] = {}
-    duplicate_display_names: list[tuple[str, str, str]] = []
-    if not TEMPLATES_DIR.is_dir():
-        return result
-
-    for path in sorted(TEMPLATES_DIR.glob("*.json")):
-        if path.name in _SKIP_TEMPLATES:
-            continue
-        if not include_audio and _is_audio_template(path.name):
-            continue
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            TemplateConfig(**data)
-            display_name = _display_name_from_template(path.name, data)
-            normalized_display_name = display_name.strip().lower()
-            existing_file = seen_display_names.get(normalized_display_name)
-            if existing_file:
-                duplicate_display_names.append((display_name, existing_file, path.name))
-                continue
-            seen_display_names[normalized_display_name] = path.name
-            result[path.name] = display_name
-        except Exception as exc:
-            print(f"Skipping invalid template '{path.name}': {exc}")
-            continue
-
-    _raise_duplicate_display_names(duplicate_display_names)
-
-    return result
+    if include_audio:
+        return _discover_templates_with_predicate(lambda _filename: True)
+    return _discover_templates_with_predicate(lambda filename: not _is_audio_template(filename))
 
 
 def discover_audio_templates() -> dict[str, str]:
@@ -96,35 +103,7 @@ def discover_audio_templates() -> dict[str, str]:
     Scan TEMPLATES_DIR for audio *.json templates only, return {filename: display_name}.
     Skips files in _SKIP_TEMPLATES and invalid templates.
     """
-    result: dict[str, str] = {}
-    seen_display_names: dict[str, str] = {}
-    duplicate_display_names: list[tuple[str, str, str]] = []
-    if not TEMPLATES_DIR.is_dir():
-        return result
-
-    for path in sorted(TEMPLATES_DIR.glob("*.json")):
-        if path.name in _SKIP_TEMPLATES:
-            continue
-        if not _is_audio_template(path.name):
-            continue
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            TemplateConfig(**data)
-            display_name = _display_name_from_template(path.name, data)
-            normalized_display_name = display_name.strip().lower()
-            existing_file = seen_display_names.get(normalized_display_name)
-            if existing_file:
-                duplicate_display_names.append((display_name, existing_file, path.name))
-                continue
-            seen_display_names[normalized_display_name] = path.name
-            result[path.name] = display_name
-        except Exception as exc:
-            print(f"Skipping invalid template '{path.name}': {exc}")
-            continue
-
-    _raise_duplicate_display_names(duplicate_display_names)
-
-    return result
+    return _discover_templates_with_predicate(_is_audio_template)
 
 
 _cache: dict[str, str] | None = None

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -40,6 +40,18 @@ def _deployment_name_from_filename(filename: str) -> str:
     return filename.removesuffix(".json").lower()
 
 
+def _raise_duplicate_display_names(duplicates: list[tuple[str, str, str]]) -> None:
+    """Raise a clear error when duplicate template display names are detected."""
+    if not duplicates:
+        return
+
+    details = "; ".join(
+        f"'{display_name}' used by {first_file} and {second_file}"
+        for display_name, first_file, second_file in duplicates
+    )
+    raise ValueError(f"Duplicate template display_name values found: {details}")
+
+
 def discover_templates(include_audio: bool = False) -> dict[str, str]:
     """
     Scan TEMPLATES_DIR for *.json, validate each, return {filename: display_name}.
@@ -49,6 +61,8 @@ def discover_templates(include_audio: bool = False) -> dict[str, str]:
         include_audio: If False, exclude audio/whisper templates.
     """
     result: dict[str, str] = {}
+    seen_display_names: dict[str, str] = {}
+    duplicate_display_names: list[tuple[str, str, str]] = []
     if not TEMPLATES_DIR.is_dir():
         return result
 
@@ -60,9 +74,55 @@ def discover_templates(include_audio: bool = False) -> dict[str, str]:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             TemplateConfig(**data)
-            result[path.name] = _display_name_from_template(path.name, data)
-        except Exception:
+            display_name = _display_name_from_template(path.name, data)
+            normalized_display_name = display_name.strip().lower()
+            existing_file = seen_display_names.get(normalized_display_name)
+            if existing_file:
+                duplicate_display_names.append((display_name, existing_file, path.name))
+                continue
+            seen_display_names[normalized_display_name] = path.name
+            result[path.name] = display_name
+        except Exception as exc:
+            print(f"Skipping invalid template '{path.name}': {exc}")
             continue
+
+    _raise_duplicate_display_names(duplicate_display_names)
+
+    return result
+
+
+def discover_audio_templates() -> dict[str, str]:
+    """
+    Scan TEMPLATES_DIR for audio *.json templates only, return {filename: display_name}.
+    Skips files in _SKIP_TEMPLATES and invalid templates.
+    """
+    result: dict[str, str] = {}
+    seen_display_names: dict[str, str] = {}
+    duplicate_display_names: list[tuple[str, str, str]] = []
+    if not TEMPLATES_DIR.is_dir():
+        return result
+
+    for path in sorted(TEMPLATES_DIR.glob("*.json")):
+        if path.name in _SKIP_TEMPLATES:
+            continue
+        if not _is_audio_template(path.name):
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            TemplateConfig(**data)
+            display_name = _display_name_from_template(path.name, data)
+            normalized_display_name = display_name.strip().lower()
+            existing_file = seen_display_names.get(normalized_display_name)
+            if existing_file:
+                duplicate_display_names.append((display_name, existing_file, path.name))
+                continue
+            seen_display_names[normalized_display_name] = path.name
+            result[path.name] = display_name
+        except Exception as exc:
+            print(f"Skipping invalid template '{path.name}': {exc}")
+            continue
+
+    _raise_duplicate_display_names(duplicate_display_names)
 
     return result
 
@@ -83,8 +143,7 @@ def get_audio_template_map() -> dict[str, str]:
     """Return cached audio {template_filename: display_name} mapping."""
     global _audio_cache
     if _audio_cache is None:
-        all_templates = discover_templates(include_audio=True)
-        _audio_cache = {k: v for k, v in all_templates.items() if _is_audio_template(k)}
+        _audio_cache = discover_audio_templates()
     return _audio_cache
 
 
@@ -92,6 +151,5 @@ def refresh() -> dict[str, str]:
     """Re-scan the templates directory and update the cache."""
     global _cache, _audio_cache
     _cache = discover_templates()
-    all_templates = discover_templates(include_audio=True)
-    _audio_cache = {k: v for k, v in all_templates.items() if _is_audio_template(k)}
+    _audio_cache = discover_audio_templates()
     return _cache

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -27,6 +27,14 @@ def _display_name_from_filename(filename: str) -> str:
     return stem[0].upper() + stem[1:]
 
 
+def _display_name_from_template(filename: str, data: dict) -> str:
+    """Prefer explicit template display_name, then fallback to filename-derived name."""
+    display_name = data.get("display_name")
+    if isinstance(display_name, str) and display_name.strip():
+        return display_name.strip()
+    return _display_name_from_filename(filename)
+
+
 def _deployment_name_from_filename(filename: str) -> str:
     """'deepseek-7b-sglang.json' -> 'deepseek-7b-sglang'"""
     return filename.removesuffix(".json").lower()
@@ -52,7 +60,7 @@ def discover_templates(include_audio: bool = False) -> dict[str, str]:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             TemplateConfig(**data)
-            result[path.name] = _display_name_from_filename(path.name)
+            result[path.name] = _display_name_from_template(path.name, data)
         except Exception:
             continue
 

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -16,6 +16,11 @@ TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 _SKIP_TEMPLATES = {"custom-engine.json"} # not tested/validated, and not needed in the dropdowns
 
 
+def _is_audio_template(filename: str) -> bool:
+    """Audio templates are currently identified by whisper-* naming."""
+    return filename.startswith("whisper-")
+
+
 def _display_name_from_filename(filename: str) -> str:
     """'deepseek-7b-sglang.json' -> 'Deepseek-7b-sglang'"""
     stem = filename.removesuffix(".json")
@@ -27,10 +32,13 @@ def _deployment_name_from_filename(filename: str) -> str:
     return filename.removesuffix(".json").lower()
 
 
-def discover_templates() -> dict[str, str]:
+def discover_templates(include_audio: bool = False) -> dict[str, str]:
     """
     Scan TEMPLATES_DIR for *.json, validate each, return {filename: display_name}.
     Skips files in _SKIP_TEMPLATES and invalid templates.
+
+    Args:
+        include_audio: If False, exclude audio/whisper templates.
     """
     result: dict[str, str] = {}
     if not TEMPLATES_DIR.is_dir():
@@ -38,6 +46,8 @@ def discover_templates() -> dict[str, str]:
 
     for path in sorted(TEMPLATES_DIR.glob("*.json")):
         if path.name in _SKIP_TEMPLATES:
+            continue
+        if not include_audio and _is_audio_template(path.name):
             continue
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -50,6 +60,7 @@ def discover_templates() -> dict[str, str]:
 
 
 _cache: dict[str, str] | None = None
+_audio_cache: dict[str, str] | None = None
 
 
 def get_template_map() -> dict[str, str]:
@@ -60,8 +71,19 @@ def get_template_map() -> dict[str, str]:
     return _cache
 
 
+def get_audio_template_map() -> dict[str, str]:
+    """Return cached audio {template_filename: display_name} mapping."""
+    global _audio_cache
+    if _audio_cache is None:
+        all_templates = discover_templates(include_audio=True)
+        _audio_cache = {k: v for k, v in all_templates.items() if _is_audio_template(k)}
+    return _audio_cache
+
+
 def refresh() -> dict[str, str]:
     """Re-scan the templates directory and update the cache."""
-    global _cache
+    global _cache, _audio_cache
     _cache = discover_templates()
+    all_templates = discover_templates(include_audio=True)
+    _audio_cache = {k: v for k, v in all_templates.items() if _is_audio_template(k)}
     return _cache

--- a/gen-ai-playground/backend/app/template_models.py
+++ b/gen-ai-playground/backend/app/template_models.py
@@ -1,4 +1,5 @@
 
+import re
 from typing import Dict, List, Optional, Literal
 from pydantic import BaseModel, Field, model_validator
 
@@ -67,11 +68,28 @@ class CustomConfig(BaseModel):
     image: Optional[str] = None
     env: Optional[Dict[str, str]] = None
 
+    @model_validator(mode="after")
+    def validate_env_keys(self):
+        if not self.env:
+            return self
+
+        env_name_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+        for env_name in self.env.keys():
+            if not env_name_pattern.match(env_name):
+                raise ValueError(
+                    f"custom.env contains invalid key '{env_name}'. "
+                    "Env var names must match [A-Za-z_][A-Za-z0-9_]*"
+                )
+        return self
+
 
 class TemplateConfig(BaseModel):
     # Common Fields (All Engines)
     engine: Literal["vllm", "sglang", "custom"]
     model: str
+    display_name: Optional[str] = None
+    explanation: Optional[str] = None
+    short_explanation: Optional[str] = None
     trust_remote_code: Optional[bool] = None
     quantization: Optional[str] = None
     gpu_types: List[str] = Field(default_factory=list)
@@ -97,6 +115,17 @@ class TemplateConfig(BaseModel):
             raise ValueError("vllm engine requires vllm config")
         if self.engine == "custom" and not self.custom:
             raise ValueError("custom engine requires custom config")
+        if self.engine == "custom" and self.custom and not self.custom.image:
+            raise ValueError("custom engine requires custom.image")
+        if self.engine == "custom" and self.custom and self.custom.image:
+            image = self.custom.image
+            if "@sha256:" not in image:
+                last_segment = image.rsplit("/", 1)[-1]
+                if ":" not in last_segment:
+                    raise ValueError("custom.image must include a non-latest tag or digest")
+                tag = last_segment.rsplit(":", 1)[-1].lower()
+                if tag == "latest":
+                    raise ValueError("custom.image tag ':latest' is not allowed")
         return self
 
 

--- a/gen-ai-playground/backend/app/template_models.py
+++ b/gen-ai-playground/backend/app/template_models.py
@@ -1,5 +1,5 @@
 
-from typing import List, Optional, Literal
+from typing import Dict, List, Optional, Literal
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -65,6 +65,7 @@ class VLLMConfig(BaseModel):
 
 class CustomConfig(BaseModel):
     image: Optional[str] = None
+    env: Optional[Dict[str, str]] = None
 
 
 class TemplateConfig(BaseModel):

--- a/gen-ai-playground/backend/app/verda_service.py
+++ b/gen-ai-playground/backend/app/verda_service.py
@@ -355,6 +355,21 @@ class VerdaService:
                     type=EnvVarType.SECRET,
                 ),
             )
+        elif cfg.engine == "custom":
+            custom_plain_env: dict[str, str] = {}
+            if cfg.model:
+                custom_plain_env["WHISPER_MODEL"] = cfg.model
+            if cfg.custom and cfg.custom.env:
+                custom_plain_env.update(cfg.custom.env)
+
+            for env_name, env_value in custom_plain_env.items():
+                env_vars.append(
+                    EnvVar(
+                        name=env_name,
+                        value_or_reference_to_secret=str(env_value),
+                        type=EnvVarType.PLAIN,
+                    )
+                )
 
         entrypoint_overrides = EntrypointOverridesSettings(
             enabled=cfg.engine != "custom",

--- a/gen-ai-playground/backend/app/verda_service.py
+++ b/gen-ai-playground/backend/app/verda_service.py
@@ -339,13 +339,7 @@ class VerdaService:
         else:
             print("  Command: <image default entrypoint>")
 
-        env_vars: list[EnvVar] = [
-            EnvVar(
-                name="NCCL_DEBUG",
-                value_or_reference_to_secret="INFO",
-                type=EnvVarType.PLAIN,
-            ),
-        ]
+        env_vars: list[EnvVar] = []
         if cfg.engine in {"sglang", "vllm"}:
             env_vars.insert(
                 0,
@@ -355,12 +349,25 @@ class VerdaService:
                     type=EnvVarType.SECRET,
                 ),
             )
+            env_vars.append(
+                EnvVar(
+                    name="NCCL_DEBUG",
+                    value_or_reference_to_secret="INFO",
+                    type=EnvVarType.PLAIN,
+                )
+            )
         elif cfg.engine == "custom":
             custom_plain_env: dict[str, str] = {}
             if cfg.model:
                 custom_plain_env["WHISPER_MODEL"] = cfg.model
             if cfg.custom and cfg.custom.env:
                 custom_plain_env.update(cfg.custom.env)
+
+            # Safety fallback: keep Whisper custom templates on GPU even if
+            # a stale template payload does not include explicit env values.
+            if template_json.startswith("whisper-"):
+                custom_plain_env.setdefault("WHISPER_DEVICE", "cuda")
+                custom_plain_env.setdefault("WHISPER_COMPUTE_TYPE", "float16")
 
             for env_name, env_value in custom_plain_env.items():
                 env_vars.append(

--- a/gen-ai-playground/backend/app/verda_service.py
+++ b/gen-ai-playground/backend/app/verda_service.py
@@ -147,8 +147,8 @@ class VerdaService:
             return cmd
 
         elif cfg.engine == "custom":
-            # Custom engine: caller must provide image; no default command
-            raise RuntimeError("Custom engine templates must provide their own entrypoint via the image")
+            # Custom engine uses image entrypoint by default (no override command).
+            return []
 
         else:
             raise RuntimeError(f"Unsupported engine: {cfg.engine}")
@@ -175,19 +175,34 @@ class VerdaService:
             image = cfg.custom.image
             if ":" not in image and cfg.image_tag:
                 image = f"{image}:{cfg.image_tag}"
+
+            # Verda rejects untagged images and the ':latest' tag.
+            if "@sha256:" not in image:
+                last_segment = image.rsplit("/", 1)[-1]
+                if ":" not in last_segment:
+                    raise RuntimeError(
+                        "Custom image must include a non-latest tag or digest (example: your-repo/whisper-service:v0.1.0)."
+                    )
+                tag = last_segment.rsplit(":", 1)[-1].lower()
+                if tag == "latest":
+                    raise RuntimeError(
+                        "Custom image tag ':latest' is not allowed. Use a versioned tag or digest."
+                    )
             return image
 
         raise RuntimeError(f"Cannot resolve image for engine: {cfg.engine}")
     
-    def available_models(self) -> list[dict]:
-        """Return template name and availability from all JSON templates."""
-        from app.template_discovery import get_template_map
-        
+    def available_models(self, template_map: Optional[dict[str, str]] = None) -> list[dict]:
+        """Return template names and availability from a template map."""
+        if template_map is None:
+            from app.template_discovery import get_template_map
+            template_map = get_template_map()
+
         # Fetch available resources once to avoid multiple api calls in the loop
         all_resources = self.check_compute_resources(1)
 
         results = []
-        for template_name, display_name in get_template_map().items():
+        for template_name, display_name in template_map.items():
             cfg = self._parse_and_validate_template(template_name)
             compute_name, gpu_count = self._resolve_gpu(cfg, all_resources)
             
@@ -284,8 +299,6 @@ class VerdaService:
         Returns:
             dict with deployment info (name, status, model)
         """
-        from app.template_models import TemplateConfig
-
         # Parse and validate template
         cfg = self._parse_and_validate_template(template_json)
 
@@ -293,7 +306,7 @@ class VerdaService:
         # Add host and port defaults, and model path 
         cfg.host = "0.0.0.0"
         if not cfg.port:
-            cfg.port = APP_PORT
+            cfg.port = 9000 if cfg.engine == "custom" else APP_PORT
 
         client = self._get_client()
 
@@ -301,8 +314,9 @@ class VerdaService:
         if deployment_name is None:
             from app.template_discovery import _deployment_name_from_filename
             deployment_name = _deployment_name_from_filename(template_json)      
-        # ensure hf secret exists
-        self._ensure_hf_secret()
+        # ensure hf secret exists when model engine needs model downloads
+        if cfg.engine in {"sglang", "vllm"}:
+            self._ensure_hf_secret()
         
         # Check compute resources and determine compute name and GPU count
         compute_name, gpu_count = self._resolve_gpu(cfg)
@@ -315,12 +329,45 @@ class VerdaService:
         # Resolve image
         image = self._resolve_image_from_template(cfg)
 
-        print(f"Deploying from template...")
+        print("Deploying from template...")
         print(f"  Model: {cfg.model}")
         print(f"  Engine: {cfg.engine}")
         print(f"  Image: {image}")
         print(f"  GPU: {gpu_count} + {compute_name}")
-        print(f"  Command: {' '.join(cmd)}")
+        if cmd:
+            print(f"  Command: {' '.join(cmd)}")
+        else:
+            print("  Command: <image default entrypoint>")
+
+        env_vars: list[EnvVar] = [
+            EnvVar(
+                name="NCCL_DEBUG",
+                value_or_reference_to_secret="INFO",
+                type=EnvVarType.PLAIN,
+            ),
+        ]
+        if cfg.engine in {"sglang", "vllm"}:
+            env_vars.insert(
+                0,
+                EnvVar(
+                    name="HF_TOKEN",
+                    value_or_reference_to_secret=HF_SECRET_NAME,
+                    type=EnvVarType.SECRET,
+                ),
+            )
+
+        entrypoint_overrides = EntrypointOverridesSettings(
+            enabled=cfg.engine != "custom",
+            cmd=cmd,
+        )
+
+        volume_mounts = []
+        if cfg.engine in {"sglang", "vllm"}:
+            volume_mounts = [VolumeMount(
+                type=VolumeMountType.MEMORY,
+                mount_path="/dev/shm",
+                size_in_mb=2048,
+            )]
 
         # Build Verda container
         container = Container(
@@ -329,28 +376,9 @@ class VerdaService:
             healthcheck=HealthcheckSettings(
                 enabled=True, port=cfg.port, path="/health"
             ),
-            entrypoint_overrides=EntrypointOverridesSettings(
-                enabled=True,
-                cmd=cmd,
-            ),
-            env=[
-                EnvVar(
-                    name="HF_TOKEN",
-                    value_or_reference_to_secret=HF_SECRET_NAME,
-                    type=EnvVarType.SECRET,
-                ),
-                EnvVar(
-                    name="NCCL_DEBUG",
-                    value_or_reference_to_secret="INFO",
-                    type=EnvVarType.PLAIN,
-                ),
-            ],
-            # for bigger models->
-            volume_mounts=[VolumeMount(
-                type=VolumeMountType.MEMORY,
-                mount_path="/dev/shm",
-                size_in_mb=2048,
-            )],
+            entrypoint_overrides=entrypoint_overrides,
+            env=env_vars,
+            volume_mounts=volume_mounts,
         )
 
         scaling_options = ScalingOptions(

--- a/gen-ai-playground/backend/server.py
+++ b/gen-ai-playground/backend/server.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.routers import auth, images, text, dashboard, invitations
+from app.routers import auth, images, text, dashboard, invitations, audio
 
 
 # Initialize FastAPI app
@@ -34,6 +34,7 @@ app.include_router(images.router)
 app.include_router(text.router)
 app.include_router(dashboard.router)
 app.include_router(invitations.router)
+app.include_router(audio.router)
 
 
 @app.get("/")

--- a/gen-ai-playground/backend/templates/whisper-faster-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-custom.json
@@ -6,7 +6,11 @@
   "short_explanation": "Whisper Faster-Whisper custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v1"
+    "image": "honjen/whisper-service:v5",
+    "env": {
+      "WHISPER_DEVICE": "cuda",
+      "WHISPER_COMPUTE_TYPE": "float16"
+    }
   },
   "port": 9000
 }

--- a/gen-ai-playground/backend/templates/whisper-faster-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-custom.json
@@ -1,0 +1,11 @@
+{
+  "engine": "custom",
+  "model": "openai/whisper-large-v3-turbo",
+  "explanation": "Deploy a custom Faster-Whisper HTTP service container for transcription.",
+  "short_explanation": "Whisper Faster-Whisper custom container",
+  "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
+  "custom": {
+    "image": "honjen/whisper-service:v1"
+  },
+  "port": 9000
+}

--- a/gen-ai-playground/backend/templates/whisper-faster-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-custom.json
@@ -6,7 +6,7 @@
   "short_explanation": "Whisper Faster-Whisper custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v5",
+    "image": "ghcr.io/tkt20007-generative-ai-playground/faster-whisper:v1",
     "env": {
       "WHISPER_DEVICE": "cuda",
       "WHISPER_COMPUTE_TYPE": "float16"

--- a/gen-ai-playground/backend/templates/whisper-faster-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-custom.json
@@ -1,5 +1,6 @@
 {
   "engine": "custom",
+  "display_name": "Whisper Large v3 Turbo",
   "model": "openai/whisper-large-v3-turbo",
   "explanation": "Deploy a custom Faster-Whisper HTTP service container for transcription.",
   "short_explanation": "Whisper Faster-Whisper custom container",

--- a/gen-ai-playground/backend/templates/whisper-faster-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-custom.json
@@ -1,7 +1,7 @@
 {
   "engine": "custom",
   "display_name": "Whisper Large v3 Turbo",
-  "model": "openai/whisper-large-v3-turbo",
+  "model": "whisper-large-v3-turbo",
   "explanation": "Deploy a custom Faster-Whisper HTTP service container for transcription.",
   "short_explanation": "Whisper Faster-Whisper custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],

--- a/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
@@ -6,7 +6,11 @@
   "short_explanation": "Whisper Faster-Whisper medium custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v1"
+    "image": "honjen/whisper-service:v5",
+    "env": {
+      "WHISPER_DEVICE": "cuda",
+      "WHISPER_COMPUTE_TYPE": "float16"
+    }
   },
   "port": 9000
 }

--- a/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
@@ -1,0 +1,12 @@
+{
+  "engine": "custom",
+  "display_name": "Whisper Medium",
+  "model": "medium",
+  "explanation": "Deploy Faster-Whisper custom container pinned to Whisper Medium for stronger accuracy than Small.",
+  "short_explanation": "Whisper Faster-Whisper medium custom container",
+  "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
+  "custom": {
+    "image": "honjen/whisper-service:v1"
+  },
+  "port": 9000
+}

--- a/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-medium-custom.json
@@ -6,7 +6,7 @@
   "short_explanation": "Whisper Faster-Whisper medium custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v5",
+    "image": "ghcr.io/tkt20007-generative-ai-playground/faster-whisper:v1",
     "env": {
       "WHISPER_DEVICE": "cuda",
       "WHISPER_COMPUTE_TYPE": "float16"

--- a/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
@@ -1,0 +1,12 @@
+{
+  "engine": "custom",
+  "display_name": "Whisper Small",
+  "model": "small",
+  "explanation": "Deploy Faster-Whisper custom container pinned to Whisper Small for faster, lower-cost transcription.",
+  "short_explanation": "Whisper Faster-Whisper small custom container",
+  "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
+  "custom": {
+    "image": "honjen/whisper-service:v1"
+  },
+  "port": 9000
+}

--- a/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
@@ -6,7 +6,7 @@
   "short_explanation": "Whisper Faster-Whisper small custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v5",
+    "image": "ghcr.io/tkt20007-generative-ai-playground/faster-whisper:v1",
     "env": {
       "WHISPER_DEVICE": "cuda",
       "WHISPER_COMPUTE_TYPE": "float16"

--- a/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-small-custom.json
@@ -6,7 +6,11 @@
   "short_explanation": "Whisper Faster-Whisper small custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v1"
+    "image": "honjen/whisper-service:v5",
+    "env": {
+      "WHISPER_DEVICE": "cuda",
+      "WHISPER_COMPUTE_TYPE": "float16"
+    }
   },
   "port": 9000
 }

--- a/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
@@ -1,0 +1,12 @@
+{
+  "engine": "custom",
+  "display_name": "Whisper Tiny",
+  "model": "tiny",
+  "explanation": "Deploy Faster-Whisper custom container pinned to Whisper Tiny for fastest, lowest-cost baseline transcription.",
+  "short_explanation": "Whisper Faster-Whisper tiny custom container",
+  "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
+  "custom": {
+    "image": "honjen/whisper-service:v1"
+  },
+  "port": 9000
+}

--- a/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
@@ -6,7 +6,11 @@
   "short_explanation": "Whisper Faster-Whisper tiny custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v1"
+    "image": "honjen/whisper-service:v5",
+    "env": {
+      "WHISPER_DEVICE": "cuda",
+      "WHISPER_COMPUTE_TYPE": "float16"
+    }
   },
   "port": 9000
 }

--- a/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
+++ b/gen-ai-playground/backend/templates/whisper-faster-tiny-custom.json
@@ -6,7 +6,7 @@
   "short_explanation": "Whisper Faster-Whisper tiny custom container",
   "gpu_types": ["b200", "h100", "h200", "a100", "l40s"],
   "custom": {
-    "image": "honjen/whisper-service:v5",
+    "image": "ghcr.io/tkt20007-generative-ai-playground/faster-whisper:v1",
     "env": {
       "WHISPER_DEVICE": "cuda",
       "WHISPER_COMPUTE_TYPE": "float16"

--- a/gen-ai-playground/backend/tests/test_audio.py
+++ b/gen-ai-playground/backend/tests/test_audio.py
@@ -313,6 +313,38 @@ class TestAudioHistoryPersistence:
         assert response.status_code == 200
         assert response.json()["text"] == "ok"
 
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._post_with_fallback_paths", new_callable=AsyncMock)
+    def test_transcribe_normalizes_unknown_source_to_none(
+        self,
+        mock_proxy_call,
+        _mock_resolve,
+        client,
+        mock_db,
+        registered_user,
+        auth_headers,
+    ):
+        mock_proxy_call.return_value = {
+            "text": "ok",
+            "model": "Whisper A",
+        }
+
+        response = client.post(
+            "/audio/transcribe",
+            headers=auth_headers,
+            data={
+                "task": "transcribe",
+                "model_path": "Whisper A",
+                "source": "mic-input",
+            },
+            files={"file": ("audio.wav", b"abc", "audio/wav")},
+        )
+
+        assert response.status_code == 200
+        record = mock_db.audio_transcriptions.find_one({"username": "audio-user"})
+        assert record is not None
+        assert record["source"] is None
+
 
 class TestAudioHistoryEndpoints:
     def test_audio_history_returns_user_items(self, client, mock_db, registered_user, auth_headers):

--- a/gen-ai-playground/backend/tests/test_audio.py
+++ b/gen-ai-playground/backend/tests/test_audio.py
@@ -1,0 +1,242 @@
+"""Tests for /audio/* endpoints."""
+
+import asyncio
+import io
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import bcrypt
+import jwt
+import mongomock
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from server import app
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock MongoDB database for testing."""
+    client = mongomock.MongoClient()
+    return client["gen_ai_playground"]
+
+
+@pytest.fixture
+def test_user_data():
+    return {
+        "username": "audio-user",
+        "password": "SecurePassword123!",
+    }
+
+
+@pytest.fixture
+def registered_user(mock_db, test_user_data):
+    hashed_password = bcrypt.hashpw(
+        test_user_data["password"].encode("utf-8"),
+        bcrypt.gensalt(),
+    )
+    mock_db.users.insert_one(
+        {
+            "username": test_user_data["username"],
+            "password": hashed_password,
+            "is_admin": True,
+            "created_at": datetime.utcnow(),
+        }
+    )
+    return test_user_data
+
+
+@pytest.fixture
+def auth_token(test_user_data):
+    payload = {
+        "username": test_user_data["username"],
+        "is_admin": True,
+        "exp": datetime.utcnow() + timedelta(hours=24),
+        "type": "access",
+    }
+    return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm="HS256")
+
+
+@pytest.fixture
+def auth_headers(auth_token):
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+@pytest.fixture
+def client(mock_db):
+    with patch("app.database.db_manager.db", mock_db):
+        with patch("app.database.get_database", return_value=mock_db):
+            yield TestClient(app)
+
+
+class TestAudioHealthAuth:
+    def test_health_requires_authentication(self, client):
+        response = client.get("/audio/health")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+
+class TestAudioEndpointSelection:
+    @patch("app.routers.audio.get_audio_template_map")
+    @patch("app.routers.audio._get_with_fallback_paths", new_callable=AsyncMock)
+    @patch("app.routers.audio.verda_service")
+    def test_health_prefers_healthy_deployment(
+        self,
+        mock_verda_service,
+        mock_whisper_health,
+        mock_template_map,
+        client,
+        registered_user,
+        auth_headers,
+    ):
+        mock_template_map.return_value = {
+            "whisper-a.json": "Whisper A",
+            "whisper-b.json": "Whisper B",
+        }
+
+        mock_verda_service.list_deployments.return_value = [
+            {"name": "whisper-a", "endpoint_url": "https://a.example"},
+            {"name": "whisper-b", "endpoint_url": "https://b.example"},
+        ]
+
+        def _status_for_name(name: str):
+            if name == "whisper-a":
+                return {"name": name, "status": "deploying"}
+            return {"name": name, "status": "healthy"}
+
+        mock_verda_service.get_deployment_status.side_effect = _status_for_name
+        mock_whisper_health.return_value = {"status": "ok"}
+
+        response = client.get("/audio/health", headers=auth_headers)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["deployment"]["name"] == "whisper-b"
+        assert payload["deployment"]["status"] == "healthy"
+        mock_whisper_health.assert_awaited_once_with("https://b.example", ["health", ""])
+
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._get_with_fallback_paths", new_callable=AsyncMock)
+    @patch("app.routers.audio.verda_service")
+    def test_health_returns_degraded_payload_when_status_lookup_fails(
+        self,
+        mock_verda_service,
+        mock_whisper_health,
+        _mock_resolve,
+        client,
+        registered_user,
+        auth_headers,
+    ):
+        mock_verda_service.get_deployment_status.side_effect = RuntimeError("verda status failed")
+
+        response = client.get("/audio/health", headers=auth_headers)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "ok"
+        assert payload["deployment"]["name"] == "whisper-a"
+        assert payload["deployment"]["status"] == "unknown"
+        assert payload["whisper"]["status"] == "unavailable"
+        assert "Unable to fetch deployment status" in payload["whisper"]["detail"]
+        mock_whisper_health.assert_not_awaited()
+
+
+class TestAudioUploadValidation:
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._post_with_fallback_paths", new_callable=AsyncMock)
+    @patch("app.routers.audio.MAX_AUDIO_UPLOAD_MB", 1)
+    @patch("app.routers.audio.MAX_AUDIO_UPLOAD_BYTES", 1024)
+    def test_transcribe_rejects_oversized_upload(
+        self,
+        mock_proxy_call,
+        _mock_resolve,
+        client,
+        registered_user,
+        auth_headers,
+    ):
+        response = client.post(
+            "/audio/transcribe",
+            headers=auth_headers,
+            data={"task": "transcribe"},
+            files={"file": ("audio.wav", b"x" * 2048, "audio/wav")},
+        )
+
+        assert response.status_code == 413
+        assert "File too large" in response.json()["detail"]
+        mock_proxy_call.assert_not_awaited()
+
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._post_with_fallback_paths", new_callable=AsyncMock)
+    @patch("app.routers.audio.MAX_AUDIO_UPLOAD_MB", 1)
+    @patch("app.routers.audio.MAX_AUDIO_UPLOAD_BYTES", 1024)
+    def test_transcribe_accepts_upload_at_exact_size_limit(
+        self,
+        mock_proxy_call,
+        _mock_resolve,
+        client,
+        registered_user,
+        auth_headers,
+    ):
+        mock_proxy_call.return_value = {"text": "ok"}
+
+        response = client.post(
+            "/audio/transcribe",
+            headers=auth_headers,
+            data={"task": "transcribe"},
+            files={"file": ("audio.wav", b"x" * 1024, "audio/wav")},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"text": "ok"}
+        mock_proxy_call.assert_awaited_once()
+
+
+class TestAudioFallbackUpload:
+    def test_post_with_fallback_paths_rewinds_file_between_attempts(self, monkeypatch):
+        from app.routers import audio as audio_router
+
+        captured_payloads: list[bytes] = []
+
+        response_not_found = Mock()
+        response_not_found.status_code = 404
+        response_not_found.raise_for_status = Mock()
+
+        response_ok = Mock()
+        response_ok.status_code = 200
+        response_ok.raise_for_status = Mock()
+        response_ok.json = Mock(return_value={"text": "ok"})
+
+        class DummyAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, _url, data=None, files=None, headers=None):
+                _ = data, headers
+                captured_payloads.append(files["file"][1].read())
+                if len(captured_payloads) == 1:
+                    return response_not_found
+                return response_ok
+
+        monkeypatch.setattr(audio_router.httpx, "AsyncClient", DummyAsyncClient)
+
+        file_obj = io.BytesIO(b"abc123")
+        result = asyncio.run(
+            audio_router._post_with_fallback_paths(
+                base_url="https://a.example",
+                paths=["transcribe", "predict"],
+                data={"task": "transcribe"},
+                file_obj=file_obj,
+                file_name="audio.wav",
+                file_content_type="audio/wav",
+            )
+        )
+
+        assert result == {"text": "ok"}
+        assert captured_payloads == [b"abc123", b"abc123"]

--- a/gen-ai-playground/backend/tests/test_audio.py
+++ b/gen-ai-playground/backend/tests/test_audio.py
@@ -383,3 +383,42 @@ class TestAudioHistoryEndpoints:
         assert len(history) == 2
         assert history[0]["transcription_text"] == "second"
         assert history[1]["transcription_text"] == "first"
+
+    def test_audio_history_sidebar_respects_limit(self, client, mock_db, registered_user, auth_headers):
+        now = datetime.utcnow()
+        mock_db.audio_transcriptions.insert_many(
+            [
+                {
+                    "type": "transcription",
+                    "transcription_text": "third",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=3),
+                    "username": "audio-user",
+                },
+                {
+                    "type": "transcription",
+                    "transcription_text": "second",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=2),
+                    "username": "audio-user",
+                },
+                {
+                    "type": "transcription",
+                    "transcription_text": "first",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=1),
+                    "username": "audio-user",
+                },
+            ]
+        )
+
+        response = client.get("/audio/history-sidebar", headers=auth_headers, params={"limit": 1})
+
+        assert response.status_code == 200
+        history = response.json()["history"]
+        assert len(history) == 1
+        assert history[0]["transcription_text"] == "first"
+
+    def test_audio_history_sidebar_rejects_invalid_limit(self, client, registered_user, auth_headers):
+        response = client.get("/audio/history-sidebar", headers=auth_headers, params={"limit": 0})
+        assert response.status_code == 422

--- a/gen-ai-playground/backend/tests/test_audio.py
+++ b/gen-ai-playground/backend/tests/test_audio.py
@@ -9,6 +9,7 @@ import bcrypt
 import jwt
 import mongomock
 import pytest
+from pymongo.errors import PyMongoError
 from fastapi.testclient import TestClient
 
 from app.config import settings
@@ -240,3 +241,145 @@ class TestAudioFallbackUpload:
 
         assert result == {"text": "ok"}
         assert captured_payloads == [b"abc123", b"abc123"]
+
+
+class TestAudioHistoryPersistence:
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._post_with_fallback_paths", new_callable=AsyncMock)
+    def test_transcribe_inserts_history_record(
+        self,
+        mock_proxy_call,
+        _mock_resolve,
+        client,
+        mock_db,
+        registered_user,
+        auth_headers,
+    ):
+        mock_proxy_call.return_value = {
+            "text": "hello transcript",
+            "model": "whisper-large-v3-turbo",
+            "language": "en",
+            "transcription_time_ms": 777,
+        }
+
+        response = client.post(
+            "/audio/transcribe",
+            headers=auth_headers,
+            data={
+                "task": "transcribe",
+                "model_path": "Whisper A",
+                "source": "uploaded",
+                "run_id": "run-123",
+            },
+            files={"file": ("audio.wav", b"abc", "audio/wav")},
+        )
+
+        assert response.status_code == 200
+
+        records = list(mock_db.audio_transcriptions.find({"type": "transcription"}))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["username"] == "audio-user"
+        assert rec["model"] == "Whisper A"
+        assert rec["transcription_text"] == "hello transcript"
+        assert rec["language"] == "en"
+        assert rec["transcription_time_ms"] == 777
+        assert rec["source"] == "uploaded"
+        assert rec["run_id"] == "run-123"
+        assert rec["input_name"] == "audio.wav"
+        assert "timestamp" in rec
+
+    @patch("app.routers.audio._resolve_audio_endpoint", return_value=("whisper-a", "https://a.example"))
+    @patch("app.routers.audio._post_with_fallback_paths", new_callable=AsyncMock)
+    def test_transcribe_still_returns_on_db_failure(
+        self,
+        mock_proxy_call,
+        _mock_resolve,
+        client,
+        mock_db,
+        registered_user,
+        auth_headers,
+    ):
+        mock_proxy_call.return_value = {"text": "ok", "model": "Whisper A"}
+
+        with patch.object(mock_db.audio_transcriptions, "insert_one", side_effect=PyMongoError("db down")):
+            response = client.post(
+                "/audio/transcribe",
+                headers=auth_headers,
+                data={"task": "transcribe", "model_path": "Whisper A"},
+                files={"file": ("audio.wav", b"abc", "audio/wav")},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["text"] == "ok"
+
+
+class TestAudioHistoryEndpoints:
+    def test_audio_history_returns_user_items(self, client, mock_db, registered_user, auth_headers):
+        now = datetime.utcnow()
+        mock_db.audio_transcriptions.insert_many(
+            [
+                {
+                    "type": "transcription",
+                    "transcription_text": "new item",
+                    "model": "whisper-a",
+                    "timestamp": now,
+                    "username": "audio-user",
+                    "transcription_time_ms": 100,
+                },
+                {
+                    "type": "transcription",
+                    "transcription_text": "old item",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=1),
+                    "username": "audio-user",
+                    "transcription_time_ms": 120,
+                },
+                {
+                    "type": "transcription",
+                    "transcription_text": "other user",
+                    "model": "whisper-b",
+                    "timestamp": now,
+                    "username": "someone-else",
+                    "transcription_time_ms": 150,
+                },
+            ]
+        )
+
+        response = client.get("/audio/history", headers=auth_headers)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 2
+        assert len(payload["history"]) == 2
+        assert payload["history"][0]["transcription_text"] == "new item"
+        assert payload["history"][1]["transcription_text"] == "old item"
+
+    def test_audio_history_sidebar_returns_sorted_items(self, client, mock_db, registered_user, auth_headers):
+        now = datetime.utcnow()
+        mock_db.audio_transcriptions.insert_many(
+            [
+                {
+                    "type": "transcription",
+                    "transcription_text": "first",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=2),
+                    "username": "audio-user",
+                },
+                {
+                    "type": "transcription",
+                    "transcription_text": "second",
+                    "model": "whisper-a",
+                    "timestamp": now - timedelta(minutes=1),
+                    "username": "audio-user",
+                },
+            ]
+        )
+
+        response = client.get("/audio/history-sidebar", headers=auth_headers)
+
+        assert response.status_code == 200
+        history = response.json()["history"]
+        assert len(history) == 2
+        assert history[0]["transcription_text"] == "second"
+        assert history[1]["transcription_text"] == "first"

--- a/gen-ai-playground/backend/tests/test_templates_audio_scope.py
+++ b/gen-ai-playground/backend/tests/test_templates_audio_scope.py
@@ -14,7 +14,7 @@ def test_custom_engine_requires_image():
         TemplateConfig.model_validate(
             {
                 "engine": "custom",
-                "model": "openai/whisper-large-v3-turbo",
+                "model": "whisper-large-v3-turbo",
                 "custom": {},
             }
         )
@@ -25,7 +25,7 @@ def test_custom_engine_rejects_latest_image_tag():
         TemplateConfig.model_validate(
             {
                 "engine": "custom",
-                "model": "openai/whisper-large-v3-turbo",
+                "model": "whisper-large-v3-turbo",
                 "custom": {"image": "repo/whisper-service:latest"},
             }
         )
@@ -36,7 +36,7 @@ def test_custom_engine_rejects_invalid_env_key():
         TemplateConfig.model_validate(
             {
                 "engine": "custom",
-                "model": "openai/whisper-large-v3-turbo",
+                "model": "whisper-large-v3-turbo",
                 "custom": {
                     "image": "repo/whisper-service:v1",
                     "env": {
@@ -55,7 +55,7 @@ def test_discovery_fails_on_duplicate_display_names(tmp_path: Path, monkeypatch)
     first = {
         "engine": "custom",
         "display_name": duplicate_name,
-        "model": "openai/whisper-large-v3-turbo",
+        "model": "whisper-large-v3-turbo",
         "gpu_types": ["l40s"],
         "custom": {"image": "repo/whisper:v1"},
         "port": 9000,
@@ -64,7 +64,7 @@ def test_discovery_fails_on_duplicate_display_names(tmp_path: Path, monkeypatch)
     second = {
         "engine": "custom",
         "display_name": duplicate_name,
-        "model": "openai/whisper-large-v3",
+        "model": "whisper-large-v3",
         "gpu_types": ["l40s"],
         "custom": {"image": "repo/whisper:v2"},
         "port": 9000,
@@ -87,7 +87,7 @@ def test_audio_map_keeps_audio_template_when_text_has_same_display_name(tmp_path
     audio = {
         "engine": "custom",
         "display_name": duplicate_name,
-        "model": "openai/whisper-large-v3-turbo",
+        "model": "whisper-large-v3-turbo",
         "gpu_types": ["l40s"],
         "custom": {"image": "repo/whisper:v1"},
         "port": 9000,

--- a/gen-ai-playground/backend/tests/test_templates_audio_scope.py
+++ b/gen-ai-playground/backend/tests/test_templates_audio_scope.py
@@ -1,0 +1,114 @@
+"""Template validation/discovery tests for recent audio/custom template work."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.template_discovery import discover_templates, get_audio_template_map
+from app.template_models import TemplateConfig
+
+
+def test_custom_engine_requires_image():
+    with pytest.raises(ValueError, match="custom.image"):
+        TemplateConfig.model_validate(
+            {
+                "engine": "custom",
+                "model": "openai/whisper-large-v3-turbo",
+                "custom": {},
+            }
+        )
+
+
+def test_custom_engine_rejects_latest_image_tag():
+    with pytest.raises(ValueError, match="latest"):
+        TemplateConfig.model_validate(
+            {
+                "engine": "custom",
+                "model": "openai/whisper-large-v3-turbo",
+                "custom": {"image": "repo/whisper-service:latest"},
+            }
+        )
+
+
+def test_custom_engine_rejects_invalid_env_key():
+    with pytest.raises(ValueError, match="invalid key"):
+        TemplateConfig.model_validate(
+            {
+                "engine": "custom",
+                "model": "openai/whisper-large-v3-turbo",
+                "custom": {
+                    "image": "repo/whisper-service:v1",
+                    "env": {
+                        "BAD-KEY": "1",
+                    },
+                },
+            }
+        )
+
+
+def test_discovery_fails_on_duplicate_display_names(tmp_path: Path, monkeypatch):
+    from app import template_discovery
+
+    duplicate_name = "Whisper Duplicate"
+
+    first = {
+        "engine": "custom",
+        "display_name": duplicate_name,
+        "model": "openai/whisper-large-v3-turbo",
+        "gpu_types": ["l40s"],
+        "custom": {"image": "repo/whisper:v1"},
+        "port": 9000,
+    }
+
+    second = {
+        "engine": "custom",
+        "display_name": duplicate_name,
+        "model": "openai/whisper-large-v3",
+        "gpu_types": ["l40s"],
+        "custom": {"image": "repo/whisper:v2"},
+        "port": 9000,
+    }
+
+    (tmp_path / "whisper-one.json").write_text(json.dumps(first), encoding="utf-8")
+    (tmp_path / "whisper-two.json").write_text(json.dumps(second), encoding="utf-8")
+
+    monkeypatch.setattr(template_discovery, "TEMPLATES_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="Duplicate template display_name"):
+        discover_templates(include_audio=True)
+
+
+def test_audio_map_keeps_audio_template_when_text_has_same_display_name(tmp_path: Path, monkeypatch):
+    from app import template_discovery
+
+    duplicate_name = "Shared Display Name"
+
+    audio = {
+        "engine": "custom",
+        "display_name": duplicate_name,
+        "model": "openai/whisper-large-v3-turbo",
+        "gpu_types": ["l40s"],
+        "custom": {"image": "repo/whisper:v1"},
+        "port": 9000,
+    }
+
+    text = {
+        "engine": "custom",
+        "display_name": duplicate_name,
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "gpu_types": ["l40s"],
+        "custom": {"image": "repo/llm:v1"},
+        "port": 9000,
+    }
+
+    (tmp_path / "whisper-one.json").write_text(json.dumps(audio), encoding="utf-8")
+    (tmp_path / "llama-one.json").write_text(json.dumps(text), encoding="utf-8")
+
+    monkeypatch.setattr(template_discovery, "TEMPLATES_DIR", tmp_path)
+    monkeypatch.setattr(template_discovery, "_audio_cache", None)
+    monkeypatch.setattr(template_discovery, "_cache", None)
+
+    audio_map = get_audio_template_map()
+
+    assert audio_map == {"whisper-one.json": duplicate_name}

--- a/gen-ai-playground/backend/tests/test_text.py
+++ b/gen-ai-playground/backend/tests/test_text.py
@@ -577,6 +577,7 @@ class TestTemplateFiles:
     def test_cmd_generation_from_template(self):
         from app.verda_service import VerdaService
         from app.template_models import TemplateConfig
+        from app.template_discovery import _SKIP_TEMPLATES
         from pathlib import Path
         
         verda_service = VerdaService()
@@ -584,7 +585,11 @@ class TestTemplateFiles:
         backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         templates_dir = Path(backend_dir) / "templates"
         
-        template_files = [f for f in templates_dir.iterdir() if f.suffix == ".json"]
+        template_files = [
+            f
+            for f in templates_dir.iterdir()
+            if f.suffix == ".json" and f.name not in _SKIP_TEMPLATES
+        ]
         assert len(template_files) > 0, "No template files found"
         
         for template_file in template_files:

--- a/gen-ai-playground/backend/tests/test_verda_service_custom.py
+++ b/gen-ai-playground/backend/tests/test_verda_service_custom.py
@@ -1,0 +1,68 @@
+"""Focused tests for Verda custom template deployment payload assembly."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.verda_service import VerdaService
+
+
+def _ns_factory(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+class TestCustomTemplateDeploymentPayload:
+    def test_custom_whisper_payload_sets_expected_env_and_skips_hf_secret(self):
+        service = VerdaService()
+
+        cfg = SimpleNamespace(
+            engine="custom",
+            model="small",
+            host=None,
+            port=None,
+            custom=SimpleNamespace(env={"EXTRA_FLAG": "1"}),
+        )
+
+        mock_client = MagicMock()
+        mock_client.containers.create_deployment.return_value = SimpleNamespace(name="whisper-faster-small-custom")
+
+        with (
+            patch.object(service, "_parse_and_validate_template", return_value=cfg),
+            patch.object(service, "_get_client", return_value=mock_client),
+            patch.object(service, "_resolve_gpu", return_value=("L40S", 1)),
+            patch.object(service, "_generate_command_from_template", return_value=[]),
+            patch.object(service, "_resolve_image_from_template", return_value="repo/whisper-service:v1"),
+            patch.object(service, "_ensure_hf_secret") as mock_ensure_hf_secret,
+            patch("app.verda_service.EnvVar", side_effect=_ns_factory),
+            patch("app.verda_service.EntrypointOverridesSettings", side_effect=_ns_factory),
+            patch("app.verda_service.HealthcheckSettings", side_effect=_ns_factory),
+            patch("app.verda_service.ScalingPolicy", side_effect=_ns_factory),
+            patch("app.verda_service.QueueLoadScalingTrigger", side_effect=_ns_factory),
+            patch("app.verda_service.UtilizationScalingTrigger", side_effect=_ns_factory),
+            patch("app.verda_service.ScalingTriggers", side_effect=_ns_factory),
+            patch("app.verda_service.ScalingOptions", side_effect=_ns_factory),
+            patch("app.verda_service.ComputeResource", side_effect=_ns_factory),
+            patch("app.verda_service.Container", side_effect=_ns_factory),
+            patch("app.verda_service.Deployment", side_effect=_ns_factory),
+        ):
+            result = service.deploy_from_template("whisper-faster-small-custom.json")
+
+        assert result["name"] == "whisper-faster-small-custom"
+        assert result["status"] == "deploying"
+        assert result["model"] == "small"
+        mock_ensure_hf_secret.assert_not_called()
+
+        deployment_payload = mock_client.containers.create_deployment.call_args.args[0]
+        container_payload = deployment_payload.containers[0]
+
+        assert deployment_payload.name == "whisper-faster-small-custom"
+        assert container_payload.image == "repo/whisper-service:v1"
+        assert container_payload.exposed_port == 9000
+        assert container_payload.entrypoint_overrides.enabled is False
+        assert container_payload.entrypoint_overrides.cmd == []
+
+        env_map = {env.name: env.value_or_reference_to_secret for env in container_payload.env}
+        assert env_map["WHISPER_MODEL"] == "small"
+        assert env_map["EXTRA_FLAG"] == "1"
+        assert env_map["WHISPER_DEVICE"] == "cuda"
+        assert env_map["WHISPER_COMPUTE_TYPE"] == "float16"
+        assert "HF_TOKEN" not in env_map

--- a/gen-ai-playground/docker-compose.dev.yml
+++ b/gen-ai-playground/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - JWT_REFRESH_SECRET_KEY=dev-refresh-secret-key-for-local-development
       - INVITATION_CODE=local-invitation-code
       - ADMIN_USERNAME=admin
-      - ADMIN_PASSWORD=local-admin-password
+      - ADMIN_PASSWORD=Localadmin123!
     volumes:
       - ./backend:/app
     depends_on:

--- a/gen-ai-playground/docker-compose.dev.yml
+++ b/gen-ai-playground/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - JWT_REFRESH_SECRET_KEY=dev-refresh-secret-key-for-local-development
       - INVITATION_CODE=local-invitation-code
       - ADMIN_USERNAME=admin
-      - ADMIN_PASSWORD=Localadmin123!
+      - ADMIN_PASSWORD=local-admin-password
     volumes:
       - ./backend:/app
     depends_on:

--- a/gen-ai-playground/docker-compose.yml
+++ b/gen-ai-playground/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - JWT_REFRESH_SECRET_KEY=dev-refresh-secret-key-for-local-development
       - INVITATION_CODE=local-invitation-code
       - ADMIN_USERNAME=admin
-      - ADMIN_PASSWORD=local-admin-password
+      - ADMIN_PASSWORD=Localadmin123!
     volumes:
       - ./backend:/app
     depends_on:

--- a/gen-ai-playground/docker-compose.yml
+++ b/gen-ai-playground/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - JWT_REFRESH_SECRET_KEY=dev-refresh-secret-key-for-local-development
       - INVITATION_CODE=local-invitation-code
       - ADMIN_USERNAME=admin
-      - ADMIN_PASSWORD=Localadmin123!
+      - ADMIN_PASSWORD=local-admin-password
     volumes:
       - ./backend:/app
     depends_on:

--- a/gen-ai-playground/frontend/package-lock.json
+++ b/gen-ai-playground/frontend/package-lock.json
@@ -8,16 +8,16 @@
       "name": "my-react-app",
       "version": "0.0.0",
       "dependencies": {
-        "@mantine/carousel": "^8.3.18",
-        "@mantine/core": "^8.3.17",
-        "@mantine/dates": "^8.3.17",
-        "@mantine/form": "^8.3.14",
-        "@mantine/hooks": "^8.3.17",
+        "@mantine/carousel": "8.3.18",
+        "@mantine/core": "8.3.18",
+        "@mantine/dates": "^8.3.18",
+        "@mantine/form": "8.3.18",
+        "@mantine/hooks": "8.3.18",
+        "@tabler/icons-react": "^3.28.1",
         "axios": "^1.13.5",
-        "embla-carousel-auto-scroll": "^8.6.0",
-        "embla-carousel-autoplay": "^8.6.0",
-        "embla-carousel-react": "^8.6.0",
         "dayjs": "^1.11.20",
+        "embla-carousel-auto-scroll": "^8.6.0",
+        "embla-carousel-react": "^8.6.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
@@ -1080,25 +1080,24 @@
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "8.3.17",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-8.3.17.tgz",
-      "integrity": "sha512-EZYxoyM91U4TqzBz5xE7HYhAcdkqdteSQQNHRQ5PPPYEewsG4SDWYxPodNfVSHd2p2mssSwsJ+peEVLQE2wt9A==",
-      "license": "MIT",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-8.3.18.tgz",
+      "integrity": "sha512-FHx5teJOhupI0gO2o5evtVYQEdqOjayOkLRhEQfB5Nc5DvcysfPfmNILGkc1Nrp9ZQeQWKLT9qr+CkcCXwHOaw==",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "8.3.17",
-        "@mantine/hooks": "8.3.17",
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
         "dayjs": ">=1.0.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/form": {
-      "version": "8.3.14",
-      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.14.tgz",
-      "integrity": "sha512-LJUeab+oF+YzATrm/K03Z/QoVVYlaolWqLUZZj7XexNA4hS2/ycKyWT07YhGkdHTLXkf3DUtrg1sS77K7Oje8A==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.18.tgz",
+      "integrity": "sha512-r5OGLJWTkmIruFjRZRZy9oA7maNYlyt50jB4Pmd2X5360WOmJLd4KH8MFhHZQC7vN+z8/rmBl3t3XGAR2I8xig==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "klona": "^2.0.6"
@@ -1697,6 +1696,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.41.1.tgz",
+      "integrity": "sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.41.1.tgz",
+      "integrity": "sha512-kUgweE+DJtAlMZVIns1FTDdcbpRVnkK7ZpUOXmoxy3JAF0rSHj0TcP4VHF14+gMJGnF+psH2Zt26BLT6owetBA==",
+      "dependencies": {
+        "@tabler/icons": "3.41.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@types/estree": {
@@ -2664,15 +2687,6 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel-auto-scroll/-/embla-carousel-auto-scroll-8.6.0.tgz",
       "integrity": "sha512-WT9fWhNXFpbQ6kP+aS07oF5IHYLZ1Dx4DkwgCY8Hv2ZyYd2KMCPfMV1q/cA3wFGuLO7GMgKiySLX90/pQkcOdQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "embla-carousel": "8.6.0"
-      }
-    },
-    "node_modules/embla-carousel-autoplay": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
-      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"

--- a/gen-ai-playground/frontend/src/components/History.tsx
+++ b/gen-ai-playground/frontend/src/components/History.tsx
@@ -187,22 +187,19 @@ export default function History() {
 
   const fetchAudioHistory = useCallback(
     async (range: [Date | null, Date | null], pageNum: number) => {
-      const headers = {
-        "Content-Type": "application/json",
-      }
-
       const params = buildParams(range, pageNum)
 
       const res = await axios.get(`${backendUrl}/audio/history`, {
-        headers,
+        headers: getAuthHeaders(),
         params,
+        withCredentials: true,
       })
 
       return {
         history: res.data.history || [],
         totalPages: res.data.total_pages || 1,
       }
-    },
+    },  
     [backendUrl],
   )
 
@@ -427,7 +424,7 @@ export default function History() {
 
             <HoverTab value="audio" leftSection={<AudioIcon />}>
               Transcribe
-              {audioHistory.length > 0 && (
+              {totalItems.audio > 0 && (
                 <Badge
                   ml={8}
                   size="xs"
@@ -441,7 +438,7 @@ export default function History() {
                     height: 18,
                   }}
                 >
-                  {audioHistory.length}
+                  {totalItems.audio}
                 </Badge>
               )}
             </HoverTab>

--- a/gen-ai-playground/frontend/src/components/History.tsx
+++ b/gen-ai-playground/frontend/src/components/History.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from "react"
 import axios from "axios"
 import { useNavigate } from "react-router-dom"
-import type { ImageRecord, PromptGroup, TextRecord } from "./history-ui/historyInterfaces"
+import type { AudioRecord, ImageRecord, PromptGroup, TextRecord } from "./history-ui/historyInterfaces"
 import DateRangePicker from "./history-ui/DateRangePicker"
 import ImageCard from "./history-ui/ImageCard"
 import TextCard from "./history-ui/TextCard"
+import AudioCard from "./history-ui/AudioCard"
 import EmptyState from "./history-ui/EmptyState"
-import { TextIcon, ImageIcon, DownloadIcon, EditIcon } from "./history-ui/Icons"
+import { TextIcon, ImageIcon, DownloadIcon, EditIcon, AudioIcon } from "./history-ui/Icons"
 import { getTypeColor, getTypeIcon, getTypeLabel, formatDate } from "./history-ui/ImageUtils"
 import { HoverTab } from "./history-ui/HoverTab"
 import {
@@ -38,20 +39,23 @@ export default function History() {
 
   const [imageHistory, setImageHistory] = useState<PromptGroup[]>([])
   const [textHistory, setTextHistory] = useState<TextRecord[]>([])
+  const [audioHistory, setAudioHistory] = useState<AudioRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedImage, setSelectedImage] = useState<ImageRecord | null>(null)
 
-  type Tab = "images" | "text"
+  type Tab = "images" | "text" | "audio"
   const [activeTab, setActiveTab] = useState<Tab>("images")
   const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([null, null])
 
   const [pages, setPages] = useState<Record<Tab, number>>({
     images: 1,
     text: 1,
+    audio: 1,
   })
   const [totalPages, setTotalPages] = useState<Record<Tab, number>>({
     images: 1,
     text: 1,
+    audio: 1,
   })
   const currentPage = pages[activeTab]
 
@@ -124,6 +128,27 @@ export default function History() {
     [backendUrl],
   )
 
+  const fetchAudioHistory = useCallback(
+    async (range: [Date | null, Date | null], pageNum: number) => {
+      const headers = {
+        "Content-Type": "application/json",
+      }
+
+      const params = buildParams(range, pageNum)
+
+      const res = await axios.get(`${backendUrl}/audio/history`, {
+        headers,
+        params,
+      })
+
+      return {
+        history: res.data.history || [],
+        totalPages: res.data.total_pages || 1,
+      }
+    },
+    [backendUrl],
+  )
+
   useEffect(() => {
     const run = async () => {
       setLoading(true)
@@ -137,13 +162,21 @@ export default function History() {
             ...prev,
             images: data.totalPages,
           }))
-        } else {
+        } else if (activeTab === "text") {
           const data = await fetchTextHistory(dateRange, currentPage)
 
           setTextHistory(data.history)
           setTotalPages(prev => ({
             ...prev,
             text: data.totalPages,
+          }))
+        } else {
+          const data = await fetchAudioHistory(dateRange, currentPage)
+
+          setAudioHistory(data.history)
+          setTotalPages(prev => ({
+            ...prev,
+            audio: data.totalPages,
           }))
         }
       } catch (err) {
@@ -154,13 +187,14 @@ export default function History() {
     }
 
     run()
-  }, [activeTab, dateRange, currentPage, fetchImagesHistory, fetchTextHistory])
+  }, [activeTab, dateRange, currentPage, fetchImagesHistory, fetchTextHistory, fetchAudioHistory])
 
   const handleDateChange = (range: [Date | null, Date | null]) => {
     setDateRange(range)
     setPages({
       images: 1,
       text: 1,
+      audio: 1,
     })
   }
 
@@ -237,6 +271,27 @@ export default function History() {
                   }}
                 >
                   {textHistory.length}
+                </Badge>
+              )}
+            </HoverTab>
+
+            <HoverTab value="audio" leftSection={<AudioIcon />}>
+              Transcribe
+              {audioHistory.length > 0 && (
+                <Badge
+                  ml={8}
+                  size="xs"
+                  variant="filled"
+                  radius="xl"
+                  style={{
+                    background: "rgba(10, 10, 10, 0.08)",
+                    color: "black",
+                    fontWeight: 600,
+                    minWidth: 22,
+                    height: 18,
+                  }}
+                >
+                  {audioHistory.length}
                 </Badge>
               )}
             </HoverTab>
@@ -329,16 +384,48 @@ export default function History() {
               </Stack>
             </ScrollArea>
           )
-        ) : textHistory.length === 0 ? (
-          <EmptyState label="No text history yet. Start a conversation to see responses here." />
+        ) : activeTab === "text" ? (
+          textHistory.length === 0 ? (
+            <EmptyState label="No text history yet. Start a conversation to see responses here." />
+          ) : (
+            <ScrollArea>
+              <Stack gap={12}>
+                {textHistory.map((item, idx) => (
+                  <Transition key={idx} mounted transition="fade" duration={200}>
+                    {styles => (
+                      <div style={{ ...styles, animationDelay: `${idx * 30}ms` }}>
+                        <TextCard item={item} />
+                      </div>
+                    )}
+                  </Transition>
+                ))}
+                <Group justify="center" mt="md">
+                  <Pagination
+                    total={totalPages[activeTab]}
+                    value={pages[activeTab]}
+                    onChange={newPage => {
+                      if (newPage == null) return
+                      setPages(prev => ({
+                        ...prev,
+                        [activeTab]: newPage,
+                      }))
+                      window.scrollTo({ top: 0, behavior: "smooth" })
+                    }}
+                  />
+                </Group>
+              </Stack>
+            </ScrollArea>
+          )
+        ) : audioHistory.length === 0 ? (
+          <EmptyState label="No transcription history yet. Run transcription to see outputs here." />
         ) : (
           <ScrollArea>
             <Stack gap={12}>
-              {textHistory.map((item, idx) => (
+              {audioHistory.map((item, idx) => (
                 <Transition key={idx} mounted transition="fade" duration={200}>
                   {styles => (
                     <div style={{ ...styles, animationDelay: `${idx * 30}ms` }}>
-                      <TextCard item={item} />
+                      <AudioCard item={item} />
                     </div>
                   )}
                 </Transition>

--- a/gen-ai-playground/frontend/src/components/HistorySidebar.tsx
+++ b/gen-ai-playground/frontend/src/components/HistorySidebar.tsx
@@ -13,6 +13,8 @@ import {
 } from "@mantine/core"
 import axios from "axios"
 import { useNavigate } from "react-router-dom"
+import { formatDate } from "./history-ui/ImageUtils"
+import { formatAudioModelName, getAudioInputTitle } from "./history-ui/audioHistoryUtils"
 
 interface ChatMessage {
   role: "user" | "assistant"
@@ -20,12 +22,18 @@ interface ChatMessage {
 }
 
 interface HistoryRecord {
-  type: "image" | "text" | "chat"
+  type: "image" | "text" | "chat" | "transcription"
   prompt?: string
   generated_text?: string
   messages?: ChatMessage[]
   reply?: string
   response?: string
+  transcription_text?: string
+  language?: string
+  transcription_time_ms?: number
+  source?: string
+  input_name?: string
+  run_id?: string
   model: string
   timestamp: string
   image_data?: string
@@ -41,7 +49,7 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
   const [limit, setLimit] = useState(5)
-  const [historyType, setHistoryType] = useState<"image" | "text">("image")
+  const [historyType, setHistoryType] = useState<"image" | "text" | "audio">("image")
 
   const conversations = []
   let last = null
@@ -74,6 +82,54 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
   conversations.sort((a, b) => b.timestamp - a.timestamp)
   const limited = conversations.slice(0, limit)
 
+  const audioRuns = []
+  let lastAudioRun = null
+
+  for (const item of items) {
+    const ts = new Date(item.timestamp).getTime()
+    const response = item.transcription_text ?? item.response ?? item.reply ?? null
+    const title = getAudioInputTitle(item)
+
+    const normalizedRunId = item.run_id?.trim() || null
+    const lastRunId = lastAudioRun?.runId ?? null
+    const hasRunIdPair = !!normalizedRunId && !!lastRunId
+
+    const isSameRun =
+      lastAudioRun &&
+      (hasRunIdPair
+        ? normalizedRunId === lastRunId
+        : Math.abs(ts - lastAudioRun.timestamp) < 10000 &&
+          (lastAudioRun.source ?? null) === (item.source ?? null))
+
+    if (isSameRun && lastAudioRun) {
+      lastAudioRun.models.push({
+        model: item.model,
+        response,
+        language: item.language,
+        transcriptionTimeMs: item.transcription_time_ms ?? null,
+      })
+    } else {
+      lastAudioRun = {
+        timestamp: ts,
+        runId: normalizedRunId,
+        source: item.source,
+        title,
+        models: [
+          {
+            model: item.model,
+            response,
+            language: item.language,
+            transcriptionTimeMs: item.transcription_time_ms ?? null,
+          },
+        ],
+      }
+      audioRuns.push(lastAudioRun)
+    }
+  }
+
+  audioRuns.sort((a, b) => b.timestamp - a.timestamp)
+  const limitedAudioRuns = audioRuns.slice(0, limit)
+
   async function refetch() {
     setLoading(true)
 
@@ -81,7 +137,9 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
       const url =
         historyType === "image"
           ? `${backendUrl}/images/history`
-          : `${backendUrl}/text/history-sidebar`
+          : historyType === "text"
+            ? `${backendUrl}/text/history-sidebar`
+            : `${backendUrl}/audio/history-sidebar`
 
       const res = await axios.get(url, { withCredentials: true })
       const history: HistoryRecord[] = res.data.history
@@ -143,13 +201,14 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
             label="Type: "
             value={historyType}
             onChange={(value: string | null) => {
-              if (value === "image" || value === "text") {
+              if (value === "image" || value === "text" || value === "audio") {
                 setHistoryType(value)
               }
             }}
             data={[
               { value: "image", label: "Generated images" },
               { value: "text", label: "Generated text" },
+              { value: "audio", label: "Transcriptions" },
             ]}
           />
 
@@ -176,7 +235,7 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
                 <Paper key={i} p="md" radius="xl" shadow="sm" withBorder bg="rgba(0,0,0,0.06)">
                   <Stack gap="xs">
                     <Text size="xs" c="dimmed">
-                      {new Date(item.timestamp).toLocaleString()}
+                      {formatDate(item.timestamp)}
                     </Text>
 
                     <Stack gap={4}>
@@ -197,6 +256,42 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
                                 ? m.response.slice(0, 50) + "..."
                                 : m.response
                               : "(no response)"}
+                          </Text>
+                        ))}
+                      </Stack>
+                    </Stack>
+                  </Stack>
+                </Paper>
+              )
+            })}
+          </>
+        )}
+
+        {historyType === "audio" && (
+          <>
+            {limitedAudioRuns.map((run, i) => {
+              return (
+                <Paper key={i} p="md" radius="xl" shadow="sm" withBorder bg="rgba(0,0,0,0.06)">
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed">
+                      {formatDate(run.timestamp)}
+                    </Text>
+
+                    <Stack gap={4}>
+                      <Text size="md" fw={600} style={{ whiteSpace: "pre-wrap" }}>
+                        {run.title}
+                      </Text>
+
+                      <Stack gap={2} mt={4}>
+                        {run.models.map((m, idx) => (
+                          <Text key={idx} size="sm" c="gray.6">
+                            <strong>{formatAudioModelName(m.model)}:</strong>{" "}
+                            {m.response
+                              ? m.response.length > 50
+                                ? m.response.slice(0, 50) + "..."
+                                : m.response
+                              : "(no transcription)"}
+                            {typeof m.transcriptionTimeMs === "number" ? ` (${m.transcriptionTimeMs} ms)` : ""}
                           </Text>
                         ))}
                       </Stack>

--- a/gen-ai-playground/frontend/src/components/HistorySidebar.tsx
+++ b/gen-ai-playground/frontend/src/components/HistorySidebar.tsx
@@ -43,6 +43,8 @@ interface HistoryRecord {
 }
 
 const backendUrl = import.meta.env.VITE_API_URL
+const AUDIO_SIDEBAR_MAX_FETCH = 200
+const AUDIO_RECORDS_PER_SESSION = 4
 
 export default function HistorySidebar({ opened }: { opened: boolean }) {
   const [items, setItems] = useState<HistoryRecord[]>([])
@@ -141,7 +143,12 @@ export default function HistorySidebar({ opened }: { opened: boolean }) {
             ? `${backendUrl}/text/history-sidebar`
             : `${backendUrl}/audio/history-sidebar`
 
-      const res = await axios.get(url, { withCredentials: true })
+      const audioFetchLimit = Math.min(AUDIO_SIDEBAR_MAX_FETCH, limit * AUDIO_RECORDS_PER_SESSION)
+
+      const res = await axios.get(url, {
+        withCredentials: true,
+        params: historyType === "audio" ? { limit: audioFetchLimit } : undefined,
+      })
       const history: HistoryRecord[] = res.data.history
 
       setItems(history)

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -4,6 +4,7 @@ import { Alert, Button, FileInput, Group, MultiSelect, Text, Textarea } from "@m
 
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
+import { formatAudioModelName } from "./history-ui/audioHistoryUtils"
 
 type TranscriptionSegment = {
   start: number
@@ -17,7 +18,6 @@ type TranscriptionResponse = {
   duration?: number
   transcription_time_ms?: number
   model?: string
-  resolved_model?: string
   segments?: TranscriptionSegment[]
 }
 
@@ -73,6 +73,13 @@ const getCsrfToken = (): string => {
   const parts = value.split(`; csrf_token=`)
   if (parts.length === 2) return parts.pop()!.split(";").shift()!
   return ""
+}
+
+const makeTranscriptionRunId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 export default function Transcribe() {
@@ -254,6 +261,9 @@ export default function Transcribe() {
       ),
     )
 
+    let succeededCount = 0
+    const runId = makeTranscriptionRunId()
+
     await Promise.all(
       modelsToRun.map(async modelValue => {
         const startedAt = Date.now()
@@ -261,6 +271,8 @@ export default function Transcribe() {
         formData.append("file", targetFile)
         formData.append("task", "transcribe")
         formData.append("model_path", modelValue)
+        formData.append("source", source)
+        formData.append("run_id", runId)
 
         try {
           const response = await axios.post<TranscriptionResponse>(`${backendUrl}/audio/transcribe`, formData, {
@@ -281,6 +293,7 @@ export default function Transcribe() {
               error: null,
             },
           }))
+          succeededCount += 1
         } catch (err: unknown) {
           setResultsByModel(prev => ({
             ...prev,
@@ -295,6 +308,10 @@ export default function Transcribe() {
         }
       }),
     )
+
+    if (succeededCount > 0) {
+      window.dispatchEvent(new Event("history-update"))
+    }
 
     setIsLoading(false)
     setActiveTranscribeSource(null)
@@ -600,10 +617,7 @@ export default function Transcribe() {
                           Language: {modelResult.data.language ?? "unknown"}
                         </Text>
                         <Text size="sm" c="dimmed">
-                          Model: {modelResult.data.model ?? "unknown"}
-                          {modelResult.data.resolved_model
-                            ? ` (resolved: ${modelResult.data.resolved_model})`
-                            : ""}
+                          Model: {formatAudioModelName(modelResult.data.model ?? "unknown")}
                         </Text>
                         {typeof modelResult.data.duration === "number" ? (
                           <Text size="sm" c="dimmed">

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -15,6 +15,7 @@ type TranscriptionResponse = {
   text: string
   language?: string
   duration?: number
+  transcription_time_ms?: number
   model?: string
   resolved_model?: string
   segments?: TranscriptionSegment[]
@@ -609,9 +610,13 @@ export default function Transcribe() {
                             Audio duration: {formatDurationMs(modelResult.data.duration * 1000, { compactMinutes: true })}
                           </Text>
                         ) : null}
-                        {typeof modelResult.elapsedMs === "number" ? (
+                        {(typeof modelResult.data.transcription_time_ms === "number" ||
+                          typeof modelResult.elapsedMs === "number") ? (
                           <Text size="sm" c="dimmed">
-                            Transcription time: {formatDurationMs(modelResult.elapsedMs, { compactMinutes: true })}
+                            Transcription time: {formatDurationMs(
+                              modelResult.data.transcription_time_ms ?? modelResult.elapsedMs ?? 0,
+                              { compactMinutes: true },
+                            )}
                           </Text>
                         ) : null}
                         {modelResult.data.segments?.length ? (

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -1,6 +1,6 @@
 import axios from "axios"
-import { useEffect, useRef, useState } from "react"
-import { Alert, Button, FileInput, Group, Paper, Stack, Text, Textarea, Title } from "@mantine/core"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Alert, Button, FileInput, Group, MultiSelect, Text, Textarea } from "@mantine/core"
 
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
@@ -21,6 +21,51 @@ type TranscriptionResponse = {
 }
 
 type TranscribeSource = "uploaded" | "recording"
+type ModelStatus = "live" | "starting" | "offline" | "unknown"
+
+type ModelOption = {
+  value: string
+  label: string
+}
+
+type ModelTranscriptionState = {
+  loading: boolean
+  startTime: number | null
+  elapsedMs: number | null
+  data: TranscriptionResponse | null
+  error: string | null
+}
+
+const MAX_AUDIO_MODELS = 4
+
+const modelStatusPriority: Record<ModelStatus, number> = {
+  live: 0,
+  starting: 1,
+  unknown: 2,
+  offline: 3,
+}
+
+function buildDropdownData(modelOptions: ModelOption[], statuses: Record<string, ModelStatus>) {
+  return modelOptions
+    .map(model => {
+      const status = statuses[model.value] ?? "unknown"
+      const isLive = status === "live"
+      const emoji = isLive ? "\u{1F7E2}" : status === "starting" ? "\u{1F7E1}" : "\u26AA"
+
+      return {
+        value: model.value,
+        label: `${emoji} ${model.label}`,
+        disabled: !isLive,
+      }
+    })
+    .sort((a, b) => {
+      const leftStatus = statuses[a.value] ?? "unknown"
+      const rightStatus = statuses[b.value] ?? "unknown"
+      const statusDiff = modelStatusPriority[leftStatus] - modelStatusPriority[rightStatus]
+      if (statusDiff !== 0) return statusDiff
+      return a.label.localeCompare(b.label)
+    })
+}
 
 const getCsrfToken = (): string => {
   const value = `; ${document.cookie}`
@@ -38,27 +83,21 @@ export default function Transcribe() {
 
   const [file, setFile] = useState<File | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [transcribeStartTime, setTranscribeStartTime] = useState<number | null>(null)
   const [isRecording, setIsRecording] = useState(false)
   const [recordingStartTime, setRecordingStartTime] = useState<number | null>(null)
-  const [recordingElapsedMs, setRecordingElapsedMs] = useState(0)
   const [recordedBlob, setRecordedBlob] = useState<Blob | null>(null)
   const [recordedAudioUrl, setRecordedAudioUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<TranscriptionResponse | null>(null)
   const [activeTranscribeSource, setActiveTranscribeSource] = useState<TranscribeSource | null>(null)
+
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>([])
+  const [modelStatuses, setModelStatuses] = useState<Record<string, ModelStatus>>({})
+  const [selectedModels, setSelectedModels] = useState<string[]>([])
+  const [resultsByModel, setResultsByModel] = useState<Record<string, ModelTranscriptionState>>({})
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const recordingChunksRef = useRef<Blob[]>([])
-  const recordingTimerRef = useRef<number | null>(null)
-
-  const clearRecordingTimer = () => {
-    if (recordingTimerRef.current !== null) {
-      window.clearInterval(recordingTimerRef.current)
-      recordingTimerRef.current = null
-    }
-  }
 
   const stopActiveStream = () => {
     if (!streamRef.current) return
@@ -70,13 +109,69 @@ export default function Transcribe() {
 
   useEffect(() => {
     return () => {
-      clearRecordingTimer()
       stopActiveStream()
       if (recordedAudioUrl) {
         URL.revokeObjectURL(recordedAudioUrl)
       }
     }
   }, [recordedAudioUrl])
+
+  const fetchAudioModels = useCallback(async () => {
+    try {
+      const response = await axios.get(`${backendUrl}/audio/models`, {
+        withCredentials: true,
+        headers: {
+          "X-CSRF-Token": getCsrfToken(),
+        },
+      })
+
+      const models: ModelOption[] = (response.data.available_models ?? []).map(
+        (model: { value: string; label: string }) => ({
+          value: model.value,
+          label: model.label,
+        }),
+      )
+      setModelOptions(models)
+    } catch {
+      // silent
+    }
+  }, [backendUrl])
+
+  const fetchAudioModelStatuses = useCallback(async () => {
+    try {
+      const response = await axios.get(`${backendUrl}/audio/model-statuses`, {
+        withCredentials: true,
+        headers: {
+          "X-CSRF-Token": getCsrfToken(),
+        },
+      })
+      setModelStatuses(response.data)
+    } catch {
+      // silent
+    }
+  }, [backendUrl])
+
+  useEffect(() => {
+    fetchAudioModels()
+    fetchAudioModelStatuses()
+  }, [fetchAudioModels, fetchAudioModelStatuses])
+
+  useEffect(() => {
+    const intervalId = window.setInterval(fetchAudioModelStatuses, 30000)
+    return () => window.clearInterval(intervalId)
+  }, [fetchAudioModelStatuses])
+
+  useEffect(() => {
+    setResultsByModel(prev => {
+      const next: Record<string, ModelTranscriptionState> = {}
+      for (const model of selectedModels) {
+        if (prev[model]) {
+          next[model] = prev[model]
+        }
+      }
+      return next
+    })
+  }, [selectedModels])
 
   const replaceRecordedAudioUrl = (nextUrl: string | null) => {
     setRecordedAudioUrl((prev: string | null) => {
@@ -94,35 +189,114 @@ export default function Transcribe() {
     return new File([blob], `recording.${extension}`, { type: mimeType })
   }
 
+  const extractErrorDetail = (err: unknown): string => {
+    const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+    if (typeof detail === "string") {
+      return detail
+    }
+    if (detail && typeof detail === "object") {
+      const message = (detail as { message?: unknown }).message
+      if (typeof message === "string") {
+        return message
+      }
+      try {
+        return JSON.stringify(detail)
+      } catch {
+        return "Transcription failed. Please try again."
+      }
+    }
+    return "Transcription failed. Please try again."
+  }
+
+  const getModelLabel = (modelValue: string): string => {
+    return modelOptions.find(model => model.value === modelValue)?.label ?? modelValue
+  }
+
+  const getModelStatusAlertColor = (status: ModelStatus): string => {
+    if (status === "starting") return "yellow"
+    return "gray"
+  }
+
+  const getModelStatusMessage = (status: ModelStatus): string | null => {
+    if (status === "live") return null
+    if (status === "starting") return "This model is starting up. It may take a minute or two."
+    if (status === "offline") return "This model is not deployed. Ask an admin to deploy it from the dashboard."
+    return "Model status is currently unknown."
+  }
+
+  const dropdownData = buildDropdownData(modelOptions, modelStatuses)
+
   const transcribeFile = async (targetFile: File, source: TranscribeSource) => {
+    if (selectedModels.length === 0) {
+      setError("Please select at least one live audio model first.")
+      return
+    }
+
     setError(null)
-    setResult(null)
     setActiveTranscribeSource(source)
     setIsLoading(true)
-    setTranscribeStartTime(Date.now())
 
-    const formData = new FormData()
-    formData.append("file", targetFile)
-    formData.append("task", "transcribe")
-
-    try {
-      const response = await axios.post<TranscriptionResponse>(`${backendUrl}/audio/transcribe`, formData, {
-        withCredentials: true,
-        headers: {
-          "X-CSRF-Token": getCsrfToken(),
+    const modelsToRun = [...selectedModels]
+    setResultsByModel(
+      modelsToRun.reduce(
+        (acc, modelValue) => {
+          acc[modelValue] = {
+            loading: true,
+            startTime: Date.now(),
+            elapsedMs: null,
+            data: null,
+            error: null,
+          }
+          return acc
         },
-        timeout: 300000,
-      })
+        {} as Record<string, ModelTranscriptionState>,
+      ),
+    )
 
-      setResult(response.data)
-    } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
-      setError(typeof detail === "string" ? detail : "Transcription failed. Please try again.")
-    } finally {
-      setIsLoading(false)
-      setTranscribeStartTime(null)
-      setActiveTranscribeSource(null)
-    }
+    await Promise.all(
+      modelsToRun.map(async modelValue => {
+        const startedAt = Date.now()
+        const formData = new FormData()
+        formData.append("file", targetFile)
+        formData.append("task", "transcribe")
+        formData.append("model_path", modelValue)
+
+        try {
+          const response = await axios.post<TranscriptionResponse>(`${backendUrl}/audio/transcribe`, formData, {
+            withCredentials: true,
+            headers: {
+              "X-CSRF-Token": getCsrfToken(),
+            },
+            timeout: 300000,
+          })
+
+          setResultsByModel(prev => ({
+            ...prev,
+            [modelValue]: {
+              loading: false,
+              startTime: prev[modelValue]?.startTime ?? null,
+              elapsedMs: Date.now() - startedAt,
+              data: response.data,
+              error: null,
+            },
+          }))
+        } catch (err: unknown) {
+          setResultsByModel(prev => ({
+            ...prev,
+            [modelValue]: {
+              loading: false,
+              startTime: prev[modelValue]?.startTime ?? null,
+              elapsedMs: Date.now() - startedAt,
+              data: null,
+              error: extractErrorDetail(err),
+            },
+          }))
+        }
+      }),
+    )
+
+    setIsLoading(false)
+    setActiveTranscribeSource(null)
   }
 
   const onTranscribeUploaded = async () => {
@@ -149,7 +323,7 @@ export default function Transcribe() {
     if (isLoading || isRecording) return
 
     setError(null)
-    setResult(null)
+    setResultsByModel({})
     setRecordedBlob(null)
     replaceRecordedAudioUrl(null)
 
@@ -173,7 +347,6 @@ export default function Transcribe() {
       }
 
       recorder.onstop = () => {
-        clearRecordingTimer()
         setIsRecording(false)
         setRecordingStartTime(null)
 
@@ -192,7 +365,6 @@ export default function Transcribe() {
       }
 
       recorder.onerror = () => {
-        clearRecordingTimer()
         setIsRecording(false)
         setRecordingStartTime(null)
         stopActiveStream()
@@ -200,18 +372,12 @@ export default function Transcribe() {
       }
 
       recorder.start()
-      const startedAt = Date.now()
       setIsRecording(true)
-      setRecordingStartTime(startedAt)
-      setRecordingElapsedMs(0)
-      recordingTimerRef.current = window.setInterval(() => {
-        setRecordingElapsedMs(Date.now() - startedAt)
-      }, 100)
+      setRecordingStartTime(Date.now())
     } catch {
       stopActiveStream()
       setIsRecording(false)
       setRecordingStartTime(null)
-      clearRecordingTimer()
       setError("Microphone permission denied or unavailable. Please allow microphone access and retry.")
     }
   }
@@ -225,127 +391,249 @@ export default function Transcribe() {
   const clearRecording = () => {
     setRecordedBlob(null)
     replaceRecordedAudioUrl(null)
-    setRecordingElapsedMs(0)
   }
-
-  const recordingDurationLabel = formatDurationMs(recordingElapsedMs, {
-    decimals: 1,
-    compactMinutes: true,
-  })
 
   const canStartRecording = !isLoading && !isRecording
   const canStopRecording = !isLoading && isRecording
-  const canTranscribeUploaded = !isLoading && !isRecording && !!file
-  const canTranscribeRecording = !isLoading && !isRecording && !!recordedBlob
+  const canTranscribeUploaded = !isLoading && !isRecording && !!file && selectedModels.length > 0
+  const canTranscribeRecording = !isLoading && !isRecording && !!recordedBlob && selectedModels.length > 0
+  const modelGridTemplateColumns =
+    selectedModels.length === 1
+      ? "minmax(320px, 1fr)"
+      : selectedModels.length === 2
+        ? "repeat(2, minmax(320px, 1fr))"
+        : "repeat(auto-fit, minmax(280px, 1fr))"
 
   const recordingButtonText = isRecording ? "Recording..." : "Start recording"
 
   return (
-    <Stack gap="md" style={{ maxWidth: 900, margin: "0 auto" }}>
-      <Title order={3}>Audio Transcription</Title>
-      <Text c="dimmed" size="sm">
-        Upload an audio file or record with your microphone, then transcribe it using the Whisper service.
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        maxWidth: "1100px",
+        margin: "0 auto",
+        padding: "20px",
+        boxSizing: "border-box",
+        gap: "16px",
+      }}
+    >
+      <Text c="dimmed" size="sm" mb={6}>
+        Select up to {MAX_AUDIO_MODELS} models for side-by-side transcription.
       </Text>
 
-      <Paper withBorder p="md" radius="md">
-        <Stack gap="sm">
-          <Text fw={600}>Upload audio file</Text>
-          <FileInput
-            label="Audio file"
-            placeholder="Choose audio file"
-            value={file}
-            onChange={setFile}
-            accept="audio/*,.wav,.mp3,.m4a,.ogg,.webm"
-            disabled={isLoading || isRecording}
-          />
+      <MultiSelect
+        label="Models"
+        placeholder={selectedModels.length > 0 ? "" : "Select models"}
+        data={dropdownData}
+        value={selectedModels}
+        onChange={setSelectedModels}
+        maxValues={MAX_AUDIO_MODELS}
+        searchable
+        clearable
+        disabled={isLoading || isRecording}
+      />
 
-          <Button
-            onClick={onTranscribeUploaded}
-            loading={isLoading && activeTranscribeSource === "uploaded"}
-            disabled={!canTranscribeUploaded}
+      {selectedModels.length > 0 ? (
+        <>
+          <div
+            style={{
+              display: "grid",
+              gap: "20px",
+              gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+              width: "100%",
+              alignItems: "stretch",
+            }}
           >
-            Transcribe uploaded file
-          </Button>
-        </Stack>
-      </Paper>
-
-      <Paper withBorder p="md" radius="md">
-        <Stack gap="sm">
-          <Text fw={600}>Record audio</Text>
-          {!recordingSupported ? (
-            <Alert color="yellow" variant="light">
-              This browser does not support microphone recording for this page.
-            </Alert>
-          ) : (
-            <>
-              <Group>
-                <Button onClick={startRecording} disabled={!canStartRecording}>
-                  {recordingButtonText}
-                </Button>
-                <Button color="orange" onClick={stopRecording} disabled={!canStopRecording}>
-                  Stop recording
-                </Button>
-                <Button variant="default" onClick={clearRecording} disabled={isRecording || !recordedBlob}>
-                  Clear recording
-                </Button>
-              </Group>
-
-              {isRecording && recordingStartTime ? (
-                <ActionStatus actionText="Recording" startTime={recordingStartTime} />
-              ) : (
-                <Text size="sm" c="dimmed">
-                  Recorded duration: {recordingDurationLabel}
-                </Text>
-              )}
-
-              {recordedAudioUrl ? <audio controls src={recordedAudioUrl} /> : null}
-
+            <div
+              style={{
+                border: "1px solid #ddd",
+                borderRadius: "8px",
+                padding: "12px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "10px",
+              }}
+            >
+              <Text fw={700}>Upload audio file</Text>
+              <FileInput
+                placeholder="Choose audio file"
+                value={file}
+                onChange={setFile}
+                accept="audio/*,.wav,.mp3,.m4a,.ogg,.webm"
+                disabled={isLoading || isRecording}
+              />
               <Button
-                onClick={onTranscribeRecording}
-                loading={isLoading && activeTranscribeSource === "recording"}
-                disabled={!canTranscribeRecording}
+                onClick={onTranscribeUploaded}
+                loading={isLoading && activeTranscribeSource === "uploaded"}
+                disabled={!canTranscribeUploaded}
               >
-                Transcribe recording
+                Transcribe uploaded file
               </Button>
-            </>
-          )}
-        </Stack>
-      </Paper>
+            </div>
 
-      {isLoading && transcribeStartTime ? <ActionStatus actionText="Transcribing" startTime={transcribeStartTime} /> : null}
+            <div
+              style={{
+                border: "1px solid #ddd",
+                borderRadius: "8px",
+                padding: "12px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "10px",
+              }}
+            >
+              <Text fw={700}>Record audio</Text>
+              {!recordingSupported ? (
+                <Alert color="yellow" variant="light">
+                  This browser does not support microphone recording for this page.
+                </Alert>
+              ) : (
+                <>
+                  <Group>
+                    <Button onClick={startRecording} disabled={!canStartRecording}>
+                      {recordingButtonText}
+                    </Button>
+                    <Button color="orange" onClick={stopRecording} disabled={!canStopRecording}>
+                      Stop recording
+                    </Button>
+                    <Button variant="default" onClick={clearRecording} disabled={isRecording || !recordedBlob}>
+                      Clear recording
+                    </Button>
+                  </Group>
 
-      {error ? (
-        <Alert color="red" variant="light">
-          {error}
-        </Alert>
+                  {isRecording && recordingStartTime ? (
+                    <ActionStatus actionText="Recording" startTime={recordingStartTime} />
+                  ) : null}
+
+                  {recordedAudioUrl ? <audio controls src={recordedAudioUrl} /> : null}
+
+                  <Button
+                    onClick={onTranscribeRecording}
+                    loading={isLoading && activeTranscribeSource === "recording"}
+                    disabled={!canTranscribeRecording}
+                  >
+                    Transcribe recording
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {error ? (
+            <Alert color="red" variant="light">
+              {error}
+            </Alert>
+          ) : null}
+
+          <div
+            style={{
+              display: "grid",
+              gap: "20px",
+              gridTemplateColumns: modelGridTemplateColumns,
+              width: "100%",
+              alignItems: "stretch",
+            }}
+          >
+            {selectedModels.map(modelValue => {
+              const modelResult = resultsByModel[modelValue]
+              const status = modelStatuses[modelValue] ?? "unknown"
+              const statusMessage = getModelStatusMessage(status)
+
+              return (
+                <div
+                  key={modelValue}
+                  style={{
+                    minWidth: 0,
+                    width: "100%",
+                    maxWidth: "100%",
+                    boxSizing: "border-box",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <Text fw={700} mb={8}>
+                    {getModelLabel(modelValue)}
+                  </Text>
+
+                  {statusMessage ? (
+                    <Alert
+                      color={getModelStatusAlertColor(status)}
+                      variant="light"
+                      mb={8}
+                      p="xs"
+                      styles={{ message: { fontSize: 13 } }}
+                    >
+                      {statusMessage}
+                    </Alert>
+                  ) : null}
+
+                  <div
+                    style={{
+                      flex: 1,
+                      minHeight: "300px",
+                      maxHeight: "65vh",
+                      border: "1px solid #ddd",
+                      borderRadius: "8px",
+                      padding: "12px",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "8px",
+                      overflowY: "auto",
+                    }}
+                  >
+                    {modelResult?.loading && modelResult.startTime ? (
+                      <ActionStatus actionText="Transcribing" startTime={modelResult.startTime} />
+                    ) : null}
+
+                    {modelResult?.error ? (
+                      <Alert color="red" variant="light">
+                        {modelResult.error}
+                      </Alert>
+                    ) : null}
+
+                    {modelResult?.data ? (
+                      <>
+                        <Textarea value={modelResult.data.text} readOnly autosize minRows={6} maxRows={16} />
+
+                        <Text size="sm" c="dimmed">
+                          Language: {modelResult.data.language ?? "unknown"}
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                          Model: {modelResult.data.model ?? "unknown"}
+                          {modelResult.data.resolved_model
+                            ? ` (resolved: ${modelResult.data.resolved_model})`
+                            : ""}
+                        </Text>
+                        {typeof modelResult.data.duration === "number" ? (
+                          <Text size="sm" c="dimmed">
+                            Audio duration: {formatDurationMs(modelResult.data.duration * 1000, { compactMinutes: true })}
+                          </Text>
+                        ) : null}
+                        {typeof modelResult.elapsedMs === "number" ? (
+                          <Text size="sm" c="dimmed">
+                            Transcription time: {formatDurationMs(modelResult.elapsedMs, { compactMinutes: true })}
+                          </Text>
+                        ) : null}
+                        {modelResult.data.segments?.length ? (
+                          <Text size="sm" c="dimmed">
+                            Segments: {modelResult.data.segments.length}
+                          </Text>
+                        ) : null}
+                      </>
+                    ) : null}
+
+                    {!modelResult ? (
+                      <Text size="sm" c="dimmed">
+                        Run transcription to see this model output.
+                      </Text>
+                    ) : null}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </>
       ) : null}
-
-      {result ? (
-        <Paper withBorder p="md" radius="md">
-          <Stack gap="xs">
-            <Text fw={600}>Transcript</Text>
-            <Textarea value={result.text} readOnly autosize minRows={6} maxRows={16} />
-
-            <Text size="sm" c="dimmed">
-              Language: {result.language ?? "unknown"}
-            </Text>
-            <Text size="sm" c="dimmed">
-              Model: {result.model ?? "unknown"}
-              {result.resolved_model ? ` (resolved: ${result.resolved_model})` : ""}
-            </Text>
-            {typeof result.duration === "number" ? (
-              <Text size="sm" c="dimmed">
-                Audio duration: {result.duration.toFixed(2)}s
-              </Text>
-            ) : null}
-            {result.segments?.length ? (
-              <Text size="sm" c="dimmed">
-                Segments: {result.segments.length}
-              </Text>
-            ) : null}
-          </Stack>
-        </Paper>
-      ) : null}
-    </Stack>
+    </div>
   )
 }

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -1,0 +1,351 @@
+import axios from "axios"
+import { useEffect, useRef, useState } from "react"
+import { Alert, Button, FileInput, Group, Paper, Stack, Text, Textarea, Title } from "@mantine/core"
+
+import ActionStatus from "./ActionStatus"
+import { formatDurationMs } from "../utils/time"
+
+type TranscriptionSegment = {
+  start: number
+  end: number
+  text: string
+}
+
+type TranscriptionResponse = {
+  text: string
+  language?: string
+  duration?: number
+  model?: string
+  resolved_model?: string
+  segments?: TranscriptionSegment[]
+}
+
+type TranscribeSource = "uploaded" | "recording"
+
+const getCsrfToken = (): string => {
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; csrf_token=`)
+  if (parts.length === 2) return parts.pop()!.split(";").shift()!
+  return ""
+}
+
+export default function Transcribe() {
+  const backendUrl = import.meta.env.VITE_API_URL || "http://localhost:8000"
+  const recordingSupported =
+    typeof navigator !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof MediaRecorder !== "undefined"
+
+  const [file, setFile] = useState<File | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [transcribeStartTime, setTranscribeStartTime] = useState<number | null>(null)
+  const [isRecording, setIsRecording] = useState(false)
+  const [recordingStartTime, setRecordingStartTime] = useState<number | null>(null)
+  const [recordingElapsedMs, setRecordingElapsedMs] = useState(0)
+  const [recordedBlob, setRecordedBlob] = useState<Blob | null>(null)
+  const [recordedAudioUrl, setRecordedAudioUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<TranscriptionResponse | null>(null)
+  const [activeTranscribeSource, setActiveTranscribeSource] = useState<TranscribeSource | null>(null)
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const recordingChunksRef = useRef<Blob[]>([])
+  const recordingTimerRef = useRef<number | null>(null)
+
+  const clearRecordingTimer = () => {
+    if (recordingTimerRef.current !== null) {
+      window.clearInterval(recordingTimerRef.current)
+      recordingTimerRef.current = null
+    }
+  }
+
+  const stopActiveStream = () => {
+    if (!streamRef.current) return
+    for (const track of streamRef.current.getTracks()) {
+      track.stop()
+    }
+    streamRef.current = null
+  }
+
+  useEffect(() => {
+    return () => {
+      clearRecordingTimer()
+      stopActiveStream()
+      if (recordedAudioUrl) {
+        URL.revokeObjectURL(recordedAudioUrl)
+      }
+    }
+  }, [recordedAudioUrl])
+
+  const replaceRecordedAudioUrl = (nextUrl: string | null) => {
+    setRecordedAudioUrl((prev: string | null) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return nextUrl
+    })
+  }
+
+  const toTranscribeFile = (blob: Blob): File => {
+    const mimeType = blob.type || "audio/webm"
+    let extension = "webm"
+    if (mimeType.includes("ogg")) extension = "ogg"
+    if (mimeType.includes("wav")) extension = "wav"
+    if (mimeType.includes("mp4") || mimeType.includes("m4a")) extension = "m4a"
+    return new File([blob], `recording.${extension}`, { type: mimeType })
+  }
+
+  const transcribeFile = async (targetFile: File, source: TranscribeSource) => {
+    setError(null)
+    setResult(null)
+    setActiveTranscribeSource(source)
+    setIsLoading(true)
+    setTranscribeStartTime(Date.now())
+
+    const formData = new FormData()
+    formData.append("file", targetFile)
+    formData.append("task", "transcribe")
+
+    try {
+      const response = await axios.post<TranscriptionResponse>(`${backendUrl}/audio/transcribe`, formData, {
+        withCredentials: true,
+        headers: {
+          "X-CSRF-Token": getCsrfToken(),
+        },
+        timeout: 300000,
+      })
+
+      setResult(response.data)
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      setError(typeof detail === "string" ? detail : "Transcription failed. Please try again.")
+    } finally {
+      setIsLoading(false)
+      setTranscribeStartTime(null)
+      setActiveTranscribeSource(null)
+    }
+  }
+
+  const onTranscribeUploaded = async () => {
+    if (!file) {
+      setError("Please choose an audio file first.")
+      return
+    }
+    await transcribeFile(file, "uploaded")
+  }
+
+  const onTranscribeRecording = async () => {
+    if (!recordedBlob) {
+      setError("Please record audio first.")
+      return
+    }
+    await transcribeFile(toTranscribeFile(recordedBlob), "recording")
+  }
+
+  const startRecording = async () => {
+    if (!recordingSupported) {
+      setError("Audio recording is not supported in this browser.")
+      return
+    }
+    if (isLoading || isRecording) return
+
+    setError(null)
+    setResult(null)
+    setRecordedBlob(null)
+    replaceRecordedAudioUrl(null)
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      streamRef.current = stream
+
+      const preferredMimeTypes = ["audio/webm;codecs=opus", "audio/webm", "audio/ogg;codecs=opus"]
+      const selectedMimeType = preferredMimeTypes.find(type => MediaRecorder.isTypeSupported(type))
+      const recorder = selectedMimeType
+        ? new MediaRecorder(stream, { mimeType: selectedMimeType })
+        : new MediaRecorder(stream)
+
+      mediaRecorderRef.current = recorder
+      recordingChunksRef.current = []
+
+      recorder.ondataavailable = event => {
+        if (event.data && event.data.size > 0) {
+          recordingChunksRef.current.push(event.data)
+        }
+      }
+
+      recorder.onstop = () => {
+        clearRecordingTimer()
+        setIsRecording(false)
+        setRecordingStartTime(null)
+
+        const outputType = recorder.mimeType || recordingChunksRef.current[0]?.type || "audio/webm"
+        const outputBlob = new Blob(recordingChunksRef.current, { type: outputType })
+
+        stopActiveStream()
+
+        if (!outputBlob.size) {
+          setError("No audio captured. Please try recording again.")
+          return
+        }
+
+        setRecordedBlob(outputBlob)
+        replaceRecordedAudioUrl(URL.createObjectURL(outputBlob))
+      }
+
+      recorder.onerror = () => {
+        clearRecordingTimer()
+        setIsRecording(false)
+        setRecordingStartTime(null)
+        stopActiveStream()
+        setError("Recording failed. Please try again.")
+      }
+
+      recorder.start()
+      const startedAt = Date.now()
+      setIsRecording(true)
+      setRecordingStartTime(startedAt)
+      setRecordingElapsedMs(0)
+      recordingTimerRef.current = window.setInterval(() => {
+        setRecordingElapsedMs(Date.now() - startedAt)
+      }, 100)
+    } catch {
+      stopActiveStream()
+      setIsRecording(false)
+      setRecordingStartTime(null)
+      clearRecordingTimer()
+      setError("Microphone permission denied or unavailable. Please allow microphone access and retry.")
+    }
+  }
+
+  const stopRecording = () => {
+    const recorder = mediaRecorderRef.current
+    if (!recorder || recorder.state === "inactive") return
+    recorder.stop()
+  }
+
+  const clearRecording = () => {
+    setRecordedBlob(null)
+    replaceRecordedAudioUrl(null)
+    setRecordingElapsedMs(0)
+  }
+
+  const recordingDurationLabel = formatDurationMs(recordingElapsedMs, {
+    decimals: 1,
+    compactMinutes: true,
+  })
+
+  const canStartRecording = !isLoading && !isRecording
+  const canStopRecording = !isLoading && isRecording
+  const canTranscribeUploaded = !isLoading && !isRecording && !!file
+  const canTranscribeRecording = !isLoading && !isRecording && !!recordedBlob
+
+  const recordingButtonText = isRecording ? "Recording..." : "Start recording"
+
+  return (
+    <Stack gap="md" style={{ maxWidth: 900, margin: "0 auto" }}>
+      <Title order={3}>Audio Transcription</Title>
+      <Text c="dimmed" size="sm">
+        Upload an audio file or record with your microphone, then transcribe it using the Whisper service.
+      </Text>
+
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="sm">
+          <Text fw={600}>Upload audio file</Text>
+          <FileInput
+            label="Audio file"
+            placeholder="Choose audio file"
+            value={file}
+            onChange={setFile}
+            accept="audio/*,.wav,.mp3,.m4a,.ogg,.webm"
+            disabled={isLoading || isRecording}
+          />
+
+          <Button
+            onClick={onTranscribeUploaded}
+            loading={isLoading && activeTranscribeSource === "uploaded"}
+            disabled={!canTranscribeUploaded}
+          >
+            Transcribe uploaded file
+          </Button>
+        </Stack>
+      </Paper>
+
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="sm">
+          <Text fw={600}>Record audio</Text>
+          {!recordingSupported ? (
+            <Alert color="yellow" variant="light">
+              This browser does not support microphone recording for this page.
+            </Alert>
+          ) : (
+            <>
+              <Group>
+                <Button onClick={startRecording} disabled={!canStartRecording}>
+                  {recordingButtonText}
+                </Button>
+                <Button color="orange" onClick={stopRecording} disabled={!canStopRecording}>
+                  Stop recording
+                </Button>
+                <Button variant="default" onClick={clearRecording} disabled={isRecording || !recordedBlob}>
+                  Clear recording
+                </Button>
+              </Group>
+
+              {isRecording && recordingStartTime ? (
+                <ActionStatus actionText="Recording" startTime={recordingStartTime} />
+              ) : (
+                <Text size="sm" c="dimmed">
+                  Recorded duration: {recordingDurationLabel}
+                </Text>
+              )}
+
+              {recordedAudioUrl ? <audio controls src={recordedAudioUrl} /> : null}
+
+              <Button
+                onClick={onTranscribeRecording}
+                loading={isLoading && activeTranscribeSource === "recording"}
+                disabled={!canTranscribeRecording}
+              >
+                Transcribe recording
+              </Button>
+            </>
+          )}
+        </Stack>
+      </Paper>
+
+      {isLoading && transcribeStartTime ? <ActionStatus actionText="Transcribing" startTime={transcribeStartTime} /> : null}
+
+      {error ? (
+        <Alert color="red" variant="light">
+          {error}
+        </Alert>
+      ) : null}
+
+      {result ? (
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Text fw={600}>Transcript</Text>
+            <Textarea value={result.text} readOnly autosize minRows={6} maxRows={16} />
+
+            <Text size="sm" c="dimmed">
+              Language: {result.language ?? "unknown"}
+            </Text>
+            <Text size="sm" c="dimmed">
+              Model: {result.model ?? "unknown"}
+              {result.resolved_model ? ` (resolved: ${result.resolved_model})` : ""}
+            </Text>
+            {typeof result.duration === "number" ? (
+              <Text size="sm" c="dimmed">
+                Audio duration: {result.duration.toFixed(2)}s
+              </Text>
+            ) : null}
+            {result.segments?.length ? (
+              <Text size="sm" c="dimmed">
+                Segments: {result.segments.length}
+              </Text>
+            ) : null}
+          </Stack>
+        </Paper>
+      ) : null}
+    </Stack>
+  )
+}

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -419,7 +419,7 @@ export default function Transcribe() {
       }}
     >
       <Text c="dimmed" size="sm" mb={6}>
-        Select up to {MAX_AUDIO_MODELS} models for side-by-side transcription.
+        Select up to {MAX_AUDIO_MODELS} models for transcription.
       </Text>
 
       <MultiSelect

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -1,6 +1,6 @@
 import axios from "axios"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Alert, Button, FileInput, Group, MultiSelect, Text, Textarea } from "@mantine/core"
+import { Alert, Button, FileInput, MultiSelect, Text, Textarea } from "@mantine/core"
 
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
@@ -507,23 +507,45 @@ export default function Transcribe() {
                 </Alert>
               ) : (
                 <>
-                  <Group>
-                    <Button onClick={startRecording} disabled={!canStartRecording}>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                      gap: "8px",
+                      width: "100%",
+                    }}
+                  >
+                    <Button onClick={startRecording} disabled={!canStartRecording} fullWidth>
                       {recordingButtonText}
                     </Button>
-                    <Button color="orange" onClick={stopRecording} disabled={!canStopRecording}>
+                    <Button color="orange" onClick={stopRecording} disabled={!canStopRecording} fullWidth>
                       Stop recording
                     </Button>
-                    <Button variant="default" onClick={clearRecording} disabled={isRecording || !recordedBlob}>
+                    <Button
+                      variant="default"
+                      onClick={clearRecording}
+                      disabled={isRecording || !recordedBlob}
+                      fullWidth
+                    >
                       Clear recording
                     </Button>
-                  </Group>
+                  </div>
 
                   {isRecording && recordingStartTime ? (
                     <ActionStatus actionText="Recording" startTime={recordingStartTime} />
                   ) : null}
 
-                  {recordedAudioUrl ? <audio controls src={recordedAudioUrl} /> : null}
+                  {recordedAudioUrl ? (
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "center",
+                        width: "100%",
+                      }}
+                    >
+                      <audio controls src={recordedAudioUrl} style={{ width: "min(100%, 440px)" }} />
+                    </div>
+                  ) : null}
 
                   <Button
                     onClick={onTranscribeRecording}
@@ -599,8 +621,10 @@ export default function Transcribe() {
                       overflowY: "auto",
                     }}
                   >
-                    {modelResult?.loading && modelResult.startTime ? (
-                      <ActionStatus actionText="Transcribing" startTime={modelResult.startTime} />
+                    {modelResult?.loading ? (
+                      <Text size="sm" c="dimmed">
+                        Transcribing...
+                      </Text>
                     ) : null}
 
                     {modelResult?.error ? (
@@ -643,7 +667,7 @@ export default function Transcribe() {
 
                     {!modelResult ? (
                       <Text size="sm" c="dimmed">
-                        Run transcription to see this model output.
+                        Run transcription to see the model's output.
                       </Text>
                     ) : null}
                   </div>

--- a/gen-ai-playground/frontend/src/components/history-ui/AudioCard.tsx
+++ b/gen-ai-playground/frontend/src/components/history-ui/AudioCard.tsx
@@ -1,0 +1,82 @@
+import { Badge, Box, Button, Group, Paper, Stack, Text } from "@mantine/core"
+import { useState } from "react"
+import type { AudioRecord } from "./historyInterfaces"
+import { formatDate } from "./ImageUtils"
+import { ClockIcon } from "./Icons"
+import { formatAudioModelName, getAudioInputTitle } from "./audioHistoryUtils"
+
+export default function AudioCard({ item }: { item: AudioRecord }) {
+  const [expanded, setExpanded] = useState(false)
+  const title = getAudioInputTitle(item)
+  const modelLabel = formatAudioModelName(item.model)
+  const transcript = item.transcription_text ?? ""
+  const isLong = transcript.length > 320
+  const displayText = isLong && !expanded ? `${transcript.slice(0, 320)}…` : transcript
+
+  return (
+    <Paper
+      p="md"
+      radius="lg"
+      style={{
+        background: "rgba(255,255,255,0.025)",
+        border: "1px solid rgba(255,255,255,0.06)",
+      }}
+    >
+      <Stack gap="xs">
+        <Text
+          size="sm"
+          fw={600}
+          style={{
+            color: "black",
+            lineHeight: 1.45,
+          }}
+        >
+          {title}
+        </Text>
+
+        <Text size="sm" style={{ color: "black", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+          {displayText || "(No transcription text)"}
+        </Text>
+
+        {isLong ? (
+          <Button
+            variant="subtle"
+            size="compact-xs"
+            color="gray"
+            style={{ width: "fit-content", fontSize: 11, opacity: 0.7 }}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? "Show less" : "Read more"}
+          </Button>
+        ) : null}
+
+        <Group gap="sm" align="center" mt={4}>
+          <Badge size="xs" variant="dot" color="teal" radius="sm" style={{ textTransform: "none" }}>
+            {modelLabel}
+          </Badge>
+
+          {item.language ? (
+            <Badge size="xs" variant="light" color="gray" radius="sm" style={{ textTransform: "none" }}>
+              {item.language}
+            </Badge>
+          ) : null}
+
+          <Group gap={4} align="center">
+            <Box c="dimmed" style={{ display: "flex" }}>
+              <ClockIcon />
+            </Box>
+            <Text size="xs" c="dimmed" style={{ fontSize: 10 }}>
+              {formatDate(item.timestamp)}
+            </Text>
+          </Group>
+
+          {typeof item.transcription_time_ms === "number" ? (
+            <Text size="xs" c="dimmed" style={{ fontSize: 10 }}>
+              {item.transcription_time_ms} ms
+            </Text>
+          ) : null}
+        </Group>
+      </Stack>
+    </Paper>
+  )
+}

--- a/gen-ai-playground/frontend/src/components/history-ui/Icons.tsx
+++ b/gen-ai-playground/frontend/src/components/history-ui/Icons.tsx
@@ -34,6 +34,23 @@ export const TextIcon = () => (
   </svg>
 )
 
+export const AudioIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 1 0 6 0V5a3 3 0 0 0-3-3z" />
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+    <line x1="12" y1="19" x2="12" y2="22" />
+  </svg>
+)
+
 export const EditIcon = () => (
   <svg
     width="14"

--- a/gen-ai-playground/frontend/src/components/history-ui/ImageUtils.tsx
+++ b/gen-ai-playground/frontend/src/components/history-ui/ImageUtils.tsx
@@ -36,7 +36,7 @@ export function getTypeIcon(type: string | null | undefined) {
       return <ImageIcon />
   }
 }
-export function formatDate(ts: string) {
+export function formatDate(ts: string | number | Date) {
   const d = new Date(ts)
   return (
     d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }) +

--- a/gen-ai-playground/frontend/src/components/history-ui/audioHistoryUtils.ts
+++ b/gen-ai-playground/frontend/src/components/history-ui/audioHistoryUtils.ts
@@ -1,0 +1,63 @@
+import type { AudioRecord } from "./historyInterfaces"
+
+export function getAudioInputTitle(item: Pick<AudioRecord, "input_name" | "source">): string {
+  const inputName = item.input_name?.trim()
+  if (inputName) {
+    return inputName
+  }
+
+  if (item.source === "recording") {
+    return "Live microphone recording"
+  }
+
+  if (item.source === "uploaded") {
+    return "Uploaded audio file"
+  }
+
+  return "Audio transcription"
+}
+
+function titleizeWhisperModel(modelId: string): string {
+  const compact = modelId.trim().toLowerCase()
+
+  const directMap: Record<string, string> = {
+    tiny: "Whisper Tiny",
+    small: "Whisper Small",
+    medium: "Whisper Medium",
+    "large-v3-turbo": "Whisper Large v3 Turbo",
+    "whisper-large-v3-turbo": "Whisper Large v3 Turbo",
+    "large-v3": "Whisper Large v3",
+    "whisper-large-v3": "Whisper Large v3",
+    "large-v2": "Whisper Large v2",
+    "whisper-large-v2": "Whisper Large v2",
+  }
+
+  if (directMap[compact]) {
+    return directMap[compact]
+  }
+
+  if (compact.startsWith("whisper-")) {
+    const body = compact.slice("whisper-".length)
+    const pretty = body
+      .split("-")
+      .map(part => (part.match(/^v\d+$/i) ? part.toLowerCase() : part.charAt(0).toUpperCase() + part.slice(1)))
+      .join(" ")
+    return `Whisper ${pretty}`
+  }
+
+  return modelId
+}
+
+export function formatAudioModelName(rawModel: string): string {
+  const value = (rawModel ?? "").trim()
+  if (!value) return "Unknown model"
+
+  const withoutVendor = value.replace(/^openai\//i, "")
+  const modelId = withoutVendor.includes("/") ? withoutVendor.split("/").pop() ?? withoutVendor : withoutVendor
+
+  if (/^whisper\s/i.test(value)) {
+    return value
+  }
+
+  return titleizeWhisperModel(modelId)
+}

--- a/gen-ai-playground/frontend/src/components/history-ui/historyInterfaces.ts
+++ b/gen-ai-playground/frontend/src/components/history-ui/historyInterfaces.ts
@@ -35,3 +35,17 @@ export interface TextRecord {
   }
   generation_time_ms?: number
 }
+
+export interface AudioRecord {
+  type: string
+  transcription_text: string
+  model: string
+  timestamp: string
+  username: string
+  run_id?: string
+  input_name?: string
+  language?: string
+  duration?: number
+  transcription_time_ms?: number
+  source?: string
+}

--- a/gen-ai-playground/frontend/src/constants/tabs.ts
+++ b/gen-ai-playground/frontend/src/constants/tabs.ts
@@ -1,5 +1,5 @@
 // Shared constants for playground tabs
-export const PLAYGROUND_TABS = ['ImageGenerator', 'ImageEditor', 'TextGenerator'] as const
+export const PLAYGROUND_TABS = ['ImageGenerator', 'ImageEditor', 'TextGenerator', 'Transcribe'] as const
 
 export type PlaygroundTab = typeof PLAYGROUND_TABS[number]
 

--- a/gen-ai-playground/frontend/src/pages/DashboardContainers.tsx
+++ b/gen-ai-playground/frontend/src/pages/DashboardContainers.tsx
@@ -19,14 +19,21 @@ interface Container {
   container_id: string
 }
 
+interface DeployOption {
+  id: string
+  modelPath: string
+  label: string
+  kind: "text" | "audio"
+}
+
 export default function DashboardContainers() {
   const [containers, setContainers] = useState<Container[]>([])
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [selectedModel, setSelectedModel] = useState<string | null>(null)
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null)
   const [deployLoading, setDeployLoading] = useState(false)
-  const [textModelOptions, setTextModelOptions] = useState<{ value: string; label: string }[]>([])
+  const [deployOptions, setDeployOptions] = useState<DeployOption[]>([])
 
   const backendUrl = import.meta.env.VITE_API_URL || "http://localhost:8000"
 
@@ -39,21 +46,46 @@ export default function DashboardContainers() {
   // Fetch available models from backend
   useEffect(() => {
     const fetchModels = async () => {
+      const headers = { "X-CSRF-Token": getCsrfToken() }
+      const options: DeployOption[] = []
+
       try {
-        const res = await axios.get(`${backendUrl}/text/models`, {
+        const textRes = await axios.get(`${backendUrl}/text/models`, {
           withCredentials: true,
-          headers: { "X-CSRF-Token": getCsrfToken() },
+          headers,
         })
-        const models = (res.data.available_models ?? []).map(
-          (m: { value: string; label: string }) => ({
-            value: m.value,
-            label: m.label,
-          }),
-        )
-        setTextModelOptions(models)
+        const textModels = (textRes.data.available_models ?? []) as Array<{ value: string; label: string }>
+        for (const model of textModels) {
+          options.push({
+            id: `text::${model.value}`,
+            modelPath: model.value,
+            label: `Text: ${model.label}`,
+            kind: "text",
+          })
+        }
       } catch {
         // silent
       }
+
+      try {
+        const audioRes = await axios.get(`${backendUrl}/audio/models`, {
+          withCredentials: true,
+          headers,
+        })
+        const audioModels = (audioRes.data.available_models ?? []) as Array<{ value: string; label: string }>
+        for (const model of audioModels) {
+          options.push({
+            id: `audio::${model.value}`,
+            modelPath: model.value,
+            label: `Audio: ${model.label}`,
+            kind: "audio",
+          })
+        }
+      } catch {
+        // silent
+      }
+
+      setDeployOptions(options)
     }
     fetchModels()
   }, [backendUrl])
@@ -100,13 +132,17 @@ export default function DashboardContainers() {
   }
 
   const handleDeploy = async () => {
-    if (!selectedModel) return
+    if (!selectedModelId) return
+    const selectedOption = deployOptions.find(option => option.id === selectedModelId)
+    if (!selectedOption) return
+
     setDeployLoading(true)
     setError(null)
     try {
+      const deployPath = selectedOption.kind === "audio" ? "/audio/deploy" : "/text/deploy"
       await axios.post(
-        `${backendUrl}/text/deploy`,
-        { model_path: selectedModel },
+        `${backendUrl}${deployPath}`,
+        { model_path: selectedOption.modelPath },
         {
           withCredentials: true,
           headers: {
@@ -162,12 +198,12 @@ export default function DashboardContainers() {
         <Select
           label="Deploy a model"
           placeholder="Select model"
-          data={textModelOptions}
-          value={selectedModel}
-          onChange={setSelectedModel}
+          data={deployOptions.map(option => ({ value: option.id, label: option.label }))}
+          value={selectedModelId}
+          onChange={setSelectedModelId}
           style={{ minWidth: 220 }}
         />
-        <Button onClick={handleDeploy} disabled={!selectedModel} loading={deployLoading}>
+        <Button onClick={handleDeploy} disabled={!selectedModelId} loading={deployLoading}>
           Deploy
         </Button>
       </Group>

--- a/gen-ai-playground/frontend/src/pages/Playground.tsx
+++ b/gen-ai-playground/frontend/src/pages/Playground.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react"
 import ImageGenerator from "../components/ImageGenerator"
 import ImageEditor from "../components/ImageEditor"
 import TextGenerator from "../components/TextGenerator"
+import Transcribe from "../components/Transcribe"
 import { PLAYGROUND_TABS } from "../constants/tabs"
 
 type Tab = (typeof PLAYGROUND_TABS)[number]
@@ -24,6 +25,7 @@ export default function Playground({ historyOpen }: { historyOpen: boolean }) {
     ImageGenerator: <ImageGenerator />,
     ImageEditor: <ImageEditor imageToEdit={imageToEdit} />,
     TextGenerator: <TextGenerator opened={historyOpen} />,
+    Transcribe: <Transcribe />,
   }
 
   // If tab is invalid, redirect to default

--- a/gen-ai-playground/whisper-service/.dockerignore
+++ b/gen-ai-playground/whisper-service/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+.env
+.env.*
+.git
+.gitignore
+README.md
+*.wav
+*.mp3
+*.m4a
+*.flac
+*.ogg

--- a/gen-ai-playground/whisper-service/Dockerfile
+++ b/gen-ai-playground/whisper-service/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Required by faster-whisper for decoding most common audio formats.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 9000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/gen-ai-playground/whisper-service/Dockerfile
+++ b/gen-ai-playground/whisper-service/Dockerfile
@@ -6,6 +6,8 @@ ENV LD_LIBRARY_PATH=/usr/local/lib/python3.11/site-packages/ctranslate2.libs:/us
 
 WORKDIR /app
 
+RUN useradd --create-home --uid 10001 appuser
+
 # Required by faster-whisper for decoding most common audio formats.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
@@ -14,8 +16,10 @@ RUN apt-get update \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py .
+COPY --chown=appuser:appuser app.py .
 
 EXPOSE 9000
+
+USER appuser
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/gen-ai-playground/whisper-service/Dockerfile
+++ b/gen-ai-playground/whisper-service/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV LD_LIBRARY_PATH=/usr/local/lib/python3.11/site-packages/ctranslate2.libs:/usr/local/lib/python3.11/site-packages/nvidia/cublas/lib:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib:/usr/local/lib/python3.11/site-packages/nvidia/cuda_nvrtc/lib:${LD_LIBRARY_PATH}
 
 WORKDIR /app
 

--- a/gen-ai-playground/whisper-service/README.md
+++ b/gen-ai-playground/whisper-service/README.md
@@ -28,9 +28,13 @@ docker build -t whisper-service:local ./whisper-service
 
 docker run --rm -p 9000:9000 \
   -e WHISPER_MODEL=openai/whisper-large-v3-turbo \
-  -e WHISPER_DEVICE=cpu \
+  -e WHISPER_DEVICE=cuda \
+  -e WHISPER_COMPUTE_TYPE=float16 \
   whisper-service:local
 ```
+
+The image installs NVIDIA CUDA runtime libraries (`nvidia-cublas-cu12`,
+`nvidia-cudnn-cu12`) so GPU transcription can load `libcublas.so.12`.
 
 ## Test with curl
 
@@ -47,6 +51,7 @@ Example response:
   "text": "hello world",
   "language": "en",
   "duration": 4.2,
+  "transcription_time_ms": 1530,
   "segments": [
     {"start": 0.0, "end": 1.2, "text": "hello"},
     {"start": 1.2, "end": 2.0, "text": " world"}
@@ -69,9 +74,23 @@ Use:
 ```bash
 docker run --rm -p 9000:9000 \
   -e WHISPER_MODEL=openai/whisper-large-v3-turbo \
-  -e WHISPER_DEVICE=cpu \
+  -e WHISPER_DEVICE=cuda \
+  -e WHISPER_COMPUTE_TYPE=float16 \
   whisper-service:local
 ```
+
+If you see an error like:
+
+`Library libcublas.so.12 is not found or cannot be loaded`
+
+rebuild and publish a fresh image tag, then redeploy template:
+
+```bash
+docker build -t honjen/whisper-service:v5 ./whisper-service
+docker push honjen/whisper-service:v5
+```
+
+The backend whisper templates are pinned to `honjen/whisper-service:v5`.
 
 Then verify:
 

--- a/gen-ai-playground/whisper-service/README.md
+++ b/gen-ai-playground/whisper-service/README.md
@@ -1,0 +1,85 @@
+# Whisper Service (Phase 1)
+
+Standalone containerized transcription API using faster-whisper.
+
+## Endpoints
+
+- `GET /health`: basic status and model config
+- `POST /transcribe`: multipart file upload transcription
+
+## Environment variables
+
+- `WHISPER_MODEL` (default: `openai/whisper-large-v3-turbo`)
+- `WHISPER_DEVICE` (default: `cpu`)
+- `WHISPER_COMPUTE_TYPE` (default: `int8`)
+- `WHISPER_DOWNLOAD_ROOT` (optional)
+- `WHISPER_PRELOAD` (default: `false`)
+- `MAX_UPLOAD_MB` (default: `50`)
+
+Model aliases are supported so you can use OpenAI naming directly:
+
+- `openai/whisper-large-v3-turbo` -> `turbo`
+- `openai/whisper-large-v3` -> `large-v3`
+
+## Build and run locally
+
+```bash
+docker build -t whisper-service:local ./whisper-service
+
+docker run --rm -p 9000:9000 \
+  -e WHISPER_MODEL=openai/whisper-large-v3-turbo \
+  -e WHISPER_DEVICE=cpu \
+  whisper-service:local
+```
+
+## Test with curl
+
+```bash
+curl -X POST "http://localhost:9000/transcribe" \
+  -F "file=@/absolute/path/to/audio.wav" \
+  -F "task=transcribe"
+```
+
+Example response:
+
+```json
+{
+  "text": "hello world",
+  "language": "en",
+  "duration": 4.2,
+  "segments": [
+    {"start": 0.0, "end": 1.2, "text": "hello"},
+    {"start": 1.2, "end": 2.0, "text": " world"}
+  ],
+  "model": "openai/whisper-large-v3-turbo",
+  "resolved_model": "turbo"
+}
+```
+
+## Troubleshooting
+
+If you see an error like:
+
+`Invalid model size 'YOUR_NEW_MODEL_NAME'`
+
+your runtime env still contains a placeholder value for `WHISPER_MODEL`.
+
+Use:
+
+```bash
+docker run --rm -p 9000:9000 \
+  -e WHISPER_MODEL=openai/whisper-large-v3-turbo \
+  -e WHISPER_DEVICE=cpu \
+  whisper-service:local
+```
+
+Then verify:
+
+```bash
+curl http://localhost:9000/health
+```
+
+Expected:
+
+- `model` is `openai/whisper-large-v3-turbo`
+- `resolved_model` is `turbo`

--- a/gen-ai-playground/whisper-service/README.md
+++ b/gen-ai-playground/whisper-service/README.md
@@ -87,11 +87,25 @@ If you see an error like:
 rebuild and publish a fresh image tag, then redeploy template:
 
 ```bash
-docker build -t honjen/whisper-service:v5 ./whisper-service
-docker push honjen/whisper-service:v5
+export GHCR_OWNER=tkt20007-generative-ai-playground
+export GHCR_REPO=gen-ai-playground
+export IMAGE=ghcr.io/${GHCR_OWNER}/${GHCR_REPO}/whisper-service:v6
+
+# Requires a token with write:packages scope.
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
+
+docker build -t "$IMAGE" ./whisper-service
+docker push "$IMAGE"
 ```
 
-The backend whisper templates are pinned to `honjen/whisper-service:v5`.
+Use lowercase values for `GHCR_OWNER` and `GHCR_REPO` even if your GitHub org/repo has uppercase letters.
+
+The backend whisper templates are pinned to `ghcr.io/tkt20007-generative-ai-playground/gen-ai-playground/whisper-service:v6`.
+
+If your cluster or runtime cannot pull the image, ensure the GHCR package is visible to your deploy target:
+
+- Public package: set package visibility to public in GitHub Packages.
+- Private package: configure an image pull secret/token in your deployment platform.
 
 Then verify:
 

--- a/gen-ai-playground/whisper-service/README.md
+++ b/gen-ai-playground/whisper-service/README.md
@@ -9,7 +9,7 @@ Standalone containerized transcription API using faster-whisper.
 
 ## Environment variables
 
-- `WHISPER_MODEL` (default: `openai/whisper-large-v3-turbo`)
+- `WHISPER_MODEL` (default: `whisper-large-v3-turbo`)
 - `WHISPER_DEVICE` (default: `cpu`)
 - `WHISPER_COMPUTE_TYPE` (default: `int8`)
 - `WHISPER_DOWNLOAD_ROOT` (optional)
@@ -35,6 +35,7 @@ docker run --rm -p 9000:9000 \
 
 The image installs NVIDIA CUDA runtime libraries (`nvidia-cublas-cu12`,
 `nvidia-cudnn-cu12`) so GPU transcription can load `libcublas.so.12`.
+The container runs as a non-root user (`appuser`) at runtime.
 
 ## Test with curl
 
@@ -56,8 +57,8 @@ Example response:
     {"start": 0.0, "end": 1.2, "text": "hello"},
     {"start": 1.2, "end": 2.0, "text": " world"}
   ],
-  "model": "openai/whisper-large-v3-turbo",
-  "resolved_model": "turbo"
+  "configured_model": "openai/whisper-large-v3-turbo",
+  "model": "whisper-large-v3-turbo"
 }
 ```
 
@@ -100,5 +101,5 @@ curl http://localhost:9000/health
 
 Expected:
 
-- `model` is `openai/whisper-large-v3-turbo`
-- `resolved_model` is `turbo`
+- `configured_model` reflects the raw `WHISPER_MODEL` env value
+- `model` is the normalized model identifier used by the service

--- a/gen-ai-playground/whisper-service/app.py
+++ b/gen-ai-playground/whisper-service/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import time
@@ -9,6 +10,7 @@ from typing import Any
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from faster_whisper import WhisperModel
 
+logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = "whisper-large-v3-turbo"
 
@@ -37,6 +39,13 @@ def _normalize_model_name(model_name: str) -> str:
     if cleaned.lower() in PLACEHOLDER_MODEL_NAMES:
         return DEFAULT_MODEL_NAME
     return cleaned
+
+
+def _canonical_model_name(model_name: str) -> str:
+    normalized = _normalize_model_name(model_name)
+    if normalized.lower().startswith("openai/"):
+        return normalized.split("/", 1)[1]
+    return normalized
 
 
 def _resolve_model_name(model_name: str) -> str:
@@ -81,11 +90,10 @@ def _startup() -> None:
 
 @app.get("/health")
 def health() -> dict[str, Any]:
-    normalized_model = _normalize_model_name(settings.model_size)
     return {
         "status": "ok",
         "configured_model": settings.model_size,
-        "model": normalized_model,
+        "model": _canonical_model_name(settings.model_size),
         "device": settings.device,
         "compute_type": settings.compute_type,
         "model_loaded": _state["model"] is not None,
@@ -145,6 +153,7 @@ async def transcribe_audio(
                 }
             )
             full_text_parts.append(seg.text)
+
         transcription_time_ms = int((time.perf_counter() - transcription_start) * 1000)
 
         return {
@@ -154,12 +163,13 @@ async def transcribe_audio(
             "segments": output_segments,
             "transcription_time_ms": transcription_time_ms,
             "configured_model": settings.model_size,
-            "model": _normalize_model_name(settings.model_size),
+            "model": _canonical_model_name(settings.model_size),
         }
     except HTTPException:
         raise
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
+    except Exception:
+        logger.exception("Transcription failed")
+        raise HTTPException(status_code=500, detail="Transcription failed") from None
     finally:
         await file.close()
         if temp_path and os.path.exists(temp_path):

--- a/gen-ai-playground/whisper-service/app.py
+++ b/gen-ai-playground/whisper-service/app.py
@@ -103,17 +103,26 @@ async def transcribe_audio(
     if task not in {"transcribe", "translate"}:
         raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
 
-    content = await file.read()
     max_bytes = settings.max_upload_mb * 1024 * 1024
-    if len(content) > max_bytes:
-        raise HTTPException(status_code=413, detail=f"File too large. Max size is {settings.max_upload_mb} MB")
 
     suffix = os.path.splitext(file.filename or "audio.bin")[1]
+    temp_path: str | None = None
 
     try:
+        bytes_written = 0
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-            tmp.write(content)
             temp_path = tmp.name
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"File too large. Max size is {settings.max_upload_mb} MB",
+                    )
+                tmp.write(chunk)
 
         model = _get_model()
         segments, info = model.transcribe(
@@ -150,5 +159,6 @@ async def transcribe_audio(
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
     finally:
-        if "temp_path" in locals() and os.path.exists(temp_path):
+        await file.close()
+        if temp_path and os.path.exists(temp_path):
             os.remove(temp_path)

--- a/gen-ai-playground/whisper-service/app.py
+++ b/gen-ai-playground/whisper-service/app.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, File, HTTPException, UploadFile
 from faster_whisper import WhisperModel
 
 
-DEFAULT_MODEL_NAME = "openai/whisper-large-v3-turbo"
+DEFAULT_MODEL_NAME = "whisper-large-v3-turbo"
 
 # Common placeholder values people leave from copy/paste examples.
 PLACEHOLDER_MODEL_NAMES = {
@@ -86,7 +86,6 @@ def health() -> dict[str, Any]:
         "status": "ok",
         "configured_model": settings.model_size,
         "model": normalized_model,
-        "resolved_model": _resolve_model_name(settings.model_size),
         "device": settings.device,
         "compute_type": settings.compute_type,
         "model_loaded": _state["model"] is not None,
@@ -156,7 +155,6 @@ async def transcribe_audio(
             "transcription_time_ms": transcription_time_ms,
             "configured_model": settings.model_size,
             "model": _normalize_model_name(settings.model_size),
-            "resolved_model": _resolve_model_name(settings.model_size),
         }
     except HTTPException:
         raise

--- a/gen-ai-playground/whisper-service/app.py
+++ b/gen-ai-playground/whisper-service/app.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from faster_whisper import WhisperModel
+
+
+DEFAULT_MODEL_NAME = "openai/whisper-large-v3-turbo"
+
+# Common placeholder values people leave from copy/paste examples.
+PLACEHOLDER_MODEL_NAMES = {
+    "your_new_model_name",
+    "your_model_name",
+    "your-model-name",
+    "model_name",
+}
+
+
+MODEL_ALIASES = {
+    "openai/whisper-large-v3-turbo": "turbo",
+    "whisper-large-v3-turbo": "turbo",
+    "large-v3-turbo": "turbo",
+    "openai/whisper-large-v3": "large-v3",
+    "whisper-large-v3": "large-v3",
+}
+
+
+def _normalize_model_name(model_name: str) -> str:
+    cleaned = model_name.strip().strip('"').strip("'")
+    if not cleaned:
+        return DEFAULT_MODEL_NAME
+    if cleaned.lower() in PLACEHOLDER_MODEL_NAMES:
+        return DEFAULT_MODEL_NAME
+    return cleaned
+
+
+def _resolve_model_name(model_name: str) -> str:
+    normalized_name = _normalize_model_name(model_name)
+    return MODEL_ALIASES.get(normalized_name.lower(), normalized_name)
+
+
+@dataclass(frozen=True)
+class WhisperSettings:
+    model_size: str = os.getenv("WHISPER_MODEL", DEFAULT_MODEL_NAME)
+    device: str = os.getenv("WHISPER_DEVICE", "cpu")
+    compute_type: str = os.getenv("WHISPER_COMPUTE_TYPE", "int8")
+    download_root: str | None = os.getenv("WHISPER_DOWNLOAD_ROOT")
+    preload: bool = os.getenv("WHISPER_PRELOAD", "false").lower() == "true"
+    max_upload_mb: int = int(os.getenv("MAX_UPLOAD_MB", "50"))
+
+
+settings = WhisperSettings()
+app = FastAPI(title="Whisper Service", version="0.1.0")
+_state: dict[str, WhisperModel | None] = {"model": None}
+
+
+def _get_model() -> WhisperModel:
+    model = _state["model"]
+    if model is None:
+        resolved_model_name = _resolve_model_name(settings.model_size)
+        model = WhisperModel(
+            resolved_model_name,
+            device=settings.device,
+            compute_type=settings.compute_type,
+            download_root=settings.download_root,
+        )
+        _state["model"] = model
+    return model
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    if settings.preload:
+        _get_model()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    normalized_model = _normalize_model_name(settings.model_size)
+    return {
+        "status": "ok",
+        "configured_model": settings.model_size,
+        "model": normalized_model,
+        "resolved_model": _resolve_model_name(settings.model_size),
+        "device": settings.device,
+        "compute_type": settings.compute_type,
+        "model_loaded": _state["model"] is not None,
+    }
+
+
+@app.post("/transcribe")
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    language: str | None = None,
+    task: str = "transcribe",
+    beam_size: int = 5,
+    vad_filter: bool = True,
+) -> dict[str, Any]:
+    if task not in {"transcribe", "translate"}:
+        raise HTTPException(status_code=400, detail="task must be either 'transcribe' or 'translate'")
+
+    content = await file.read()
+    max_bytes = settings.max_upload_mb * 1024 * 1024
+    if len(content) > max_bytes:
+        raise HTTPException(status_code=413, detail=f"File too large. Max size is {settings.max_upload_mb} MB")
+
+    suffix = os.path.splitext(file.filename or "audio.bin")[1]
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(content)
+            temp_path = tmp.name
+
+        model = _get_model()
+        segments, info = model.transcribe(
+            temp_path,
+            language=language,
+            task=task,
+            beam_size=beam_size,
+            vad_filter=vad_filter,
+        )
+
+        output_segments = []
+        full_text_parts = []
+        for seg in segments:
+            output_segments.append(
+                {
+                    "start": seg.start,
+                    "end": seg.end,
+                    "text": seg.text,
+                }
+            )
+            full_text_parts.append(seg.text)
+
+        return {
+            "text": "".join(full_text_parts).strip(),
+            "language": getattr(info, "language", None),
+            "duration": getattr(info, "duration", None),
+            "segments": output_segments,
+            "configured_model": settings.model_size,
+            "model": _normalize_model_name(settings.model_size),
+            "resolved_model": _resolve_model_name(settings.model_size),
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
+    finally:
+        if "temp_path" in locals() and os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/gen-ai-playground/whisper-service/app.py
+++ b/gen-ai-playground/whisper-service/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -125,6 +126,7 @@ async def transcribe_audio(
                 tmp.write(chunk)
 
         model = _get_model()
+        transcription_start = time.perf_counter()
         segments, info = model.transcribe(
             temp_path,
             language=language,
@@ -144,12 +146,14 @@ async def transcribe_audio(
                 }
             )
             full_text_parts.append(seg.text)
+        transcription_time_ms = int((time.perf_counter() - transcription_start) * 1000)
 
         return {
             "text": "".join(full_text_parts).strip(),
             "language": getattr(info, "language", None),
             "duration": getattr(info, "duration", None),
             "segments": output_segments,
+            "transcription_time_ms": transcription_time_ms,
             "configured_model": settings.model_size,
             "model": _normalize_model_name(settings.model_size),
             "resolved_model": _resolve_model_name(settings.model_size),

--- a/gen-ai-playground/whisper-service/requirements.txt
+++ b/gen-ai-playground/whisper-service/requirements.txt
@@ -1,6 +1,5 @@
 fastapi[standard]==0.115.12
 faster-whisper==1.1.1
 nvidia-cublas-cu12==12.9.2.10
-nvidia-cudnn-cu12==9.*
+nvidia-cudnn-cu12==9.10.2.21
 python-multipart==0.0.20
-requests

--- a/gen-ai-playground/whisper-service/requirements.txt
+++ b/gen-ai-playground/whisper-service/requirements.txt
@@ -1,4 +1,6 @@
 fastapi[standard]==0.115.12
 faster-whisper==1.1.1
+nvidia-cublas-cu12==12.9.2.10
+nvidia-cudnn-cu12==9.*
 python-multipart==0.0.20
 requests

--- a/gen-ai-playground/whisper-service/requirements.txt
+++ b/gen-ai-playground/whisper-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi[standard]==0.115.12
+faster-whisper==1.1.1
+python-multipart==0.0.20
+requests

--- a/gen-ai-playground/whisper-service/requirements.txt
+++ b/gen-ai-playground/whisper-service/requirements.txt
@@ -1,5 +1,6 @@
 fastapi[standard]==0.115.12
 faster-whisper==1.1.1
+requests==2.32.3
 nvidia-cublas-cu12==12.9.2.10
 nvidia-cudnn-cu12==9.10.2.21
 python-multipart==0.0.20


### PR DESCRIPTION
This PR introduces audio transcription support using Whisper (via Faster-Whisper), including backend APIs, deployment templates, a standalone inference service, and frontend UI.

### Backend

New /audio/* routes:
POST /audio/transcribe – proxy transcription requests to deployed Whisper containers
GET /audio/health – health check with deployment-aware fallback
GET /audio/models + /model-statuses – template discovery + live status
POST /audio/deploy – deploy Whisper models via templates (admin only)
GET /audio/history + /history-sidebar – transcription history
Upload size limits + basic normalization (model, source, etc.)
MongoDB persistence for transcription history

### Templates / Infra

New Whisper custom templates (tiny → large turbo)
Template validation improvements:
Require non-latest image tags
Validate env keys
Detect duplicate display names
Verda service updates for custom engine (no HF secret, image entrypoint)

### Whisper Service

New whisper-service (Faster-Whisper based)
Supports GPU, env-based config, health endpoint, and file uploads

### Frontend

Audio tab in history + transcription UI
Sidebar + sessionized history display

### Tests

Coverage for:
Auth + endpoint behavior
Upload size limits
Fallback routing
History persistence
Template validation
Custom deployment payloads