### PR TITLE
Remove unused endpoints

### DIFF
--- a/gen-ai-playground/backend/app/routers/text.py
+++ b/gen-ai-playground/backend/app/routers/text.py
@@ -65,11 +65,6 @@ def list_available_models(current_user: UserInfo = Depends(get_current_user)):
     available_models = verda_service.available_models()
     return {"available_models": available_models}
 
-@router.get("/available-compute")
-def get_available_compute(current_user: UserInfo = Depends(get_current_user)):
-    """for testing, check available compute resources for a given size"""
-    return verda_service.check_compute_resources(1)
-
 @router.post("/deploy", response_model=DeploymentStatusResponse)
 def deploy_model(
     request: DeployModelRequest,
@@ -306,144 +301,6 @@ def get_model_statuses(
     return result
 
 
-@router.post("/generate", response_model=TextGenerateResponse)
-def generate_text(
-    request: TextGenerateRequest,
-    current_user: UserInfo = Depends(get_current_user),
-    db: Database = Depends(get_database),
-    _: None = Depends(validate_csrf_token),
-):
-    """
-    Generate text using a deployed LLM model.
-    
-    Automatically discovers the correct deployment for the requested model.
-    The deployment must be healthy before calling this endpoint.
-    
-    Args:
-        request: Text generation parameters (prompt, max_tokens, etc.)
-        current_user: Authenticated user
-        db: Database for saving history
-        
-    Returns:
-        Generated text and metadata
-    
-    Notes:
-        Requires CSRF token validation for cookie-authenticated requests.
-    """
-    print(f"Text generation for user: {current_user.username}, prompt: {request.prompt[:50]}...")
-
-    # Discover deployment for the requested model
-    model_path = request.model_path if hasattr(request, 'model_path') and request.model_path else None
-    if model_path:
-        model_path = choose_text_model_path(model_path)
-    
-    # Find a running deployment
-    try:
-        deployments = verda_service.list_deployments()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail="Could not reach deployment service.")
-
-    deployment_name = None
-    used_model_path = model_path
-
-    if model_path:
-        # Find deployment by template filename stem
-        template_name = _resolve_template_name(request.model_path)
-        if template_name:
-            expected_dep = _deployment_name_from_filename(template_name)
-            for d in deployments:
-                if d.get("name", "").lower() == expected_dep:
-                    deployment_name = d["name"]
-                    break
-    else:
-        # Fallback: use any healthy deployment
-        client = verda_service._get_client()
-        for d in deployments:
-            try:
-                dep_status = client.containers.get_deployment_status(d["name"])
-                if dep_status == ContainerDeploymentStatus.HEALTHY:
-                    deployment_name = d["name"]
-                    configs = get_template_configs()
-                    for tpl in get_template_map():
-                        if _deployment_name_from_filename(tpl) == d["name"].lower():
-                            used_model_path = configs[tpl].model
-                            break
-                    break
-            except Exception:
-                continue
-
-    if not deployment_name:
-        raise HTTPException(
-            status_code=503,
-            detail="No suitable deployment found. Ask an admin to deploy a model.",
-        )
-
-    # Check deployment health
-    try:
-        client = verda_service._get_client()
-        dep_status = client.containers.get_deployment_status(deployment_name)
-        status_str = dep_status.value if hasattr(dep_status, 'value') else str(dep_status)
-        if status_str != "healthy":
-            raise HTTPException(
-                status_code=503,
-                detail=f"Deployment is not healthy. Current status: {status_str}. "
-                       "Wait for the deployment to become healthy before generating text.",
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Failed to check deployment status: {str(e)}")
-
-    try:
-        gen_start_time = time.perf_counter()
-        result = verda_service.generate_text(
-            deployment_name=deployment_name,
-            model_path=used_model_path or "",
-            prompt=request.prompt,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            top_p=request.top_p,
-        )
-        gen_time_ms = int((time.perf_counter() - gen_start_time) * 1000)
-
-        # Save to history in MongoDB
-        try:
-            history_record = {
-                "type": "text",
-                "prompt": request.prompt,
-                "generated_text": result["generated_text"],
-                "model": result["model"],
-                "timestamp": datetime.utcnow(),
-                "username": current_user.username,
-                "usage": result.get("usage", {}),
-                "generation_time_ms": gen_time_ms,
-            }
-            db.text_generations.insert_one(history_record)
-            print(f"Saved text generation to MongoDB for user: {current_user.username}")
-        except Exception as e:
-            print(f"Failed to save text generation to MongoDB: {e}")
-
-        return TextGenerateResponse(
-            generated_text=result["generated_text"],
-            model=result["model"],
-            prompt=request.prompt,
-            usage=result.get("usage", {}),
-            generation_time_ms=gen_time_ms,
-        )
-
-    except RuntimeError as e:
-        print(f"Generate RuntimeError: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        print(f"Generate unexpected error: {type(e).__name__}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Text generation failed: {str(e)}",
-        )
-
-
 @router.post("/chat", response_model=ChatResponse)
 def chat_with_model(
     request: ChatRequest,
@@ -590,34 +447,6 @@ def get_text_history(
 
     return {"history": records}
 
-
-@router.delete("/deploy")
-def delete_deployment(
-    deployment_name: str = Query(..., description="Name of the deployment to delete"),
-    current_user: UserInfo = Depends(get_admin_user),
-    _csrf: None = Depends(validate_csrf_token),
-):
-    """
-    Delete a specific deployment and clean up resources.
-
-    Important: Always clean up deployments when done to avoid unnecessary charges.
-
-    Args:
-        deployment_name: Name of the Verda deployment to delete.
-        current_user: Authenticated admin user.
-
-    Returns:
-        Deletion status.
-
-    Raises:
-        HTTPException: 403 if the user is not an admin.
-        HTTPException: 500 if deletion fails.
-    """
-    print(f"User {current_user.username} deleting deployment: {deployment_name}")
-    result = verda_service.delete_deployment(deployment_name)
-    if result.get("status") == "error":
-        raise HTTPException(status_code=500, detail=result.get("message"))
-    return result
 
 @router.get("/history", response_model=HistoryResponseText)
 def history(

--- a/gen-ai-playground/backend/tests/test_text.py
+++ b/gen-ai-playground/backend/tests/test_text.py
@@ -141,23 +141,7 @@ def _setup_deployment_discovery(mock_vs, healthy=True):
 # ===========================================================================
 
 class TestHealthGating:
-    """POST /text/generate and /text/chat must reject when deployment is unhealthy."""
-
-    @patch("app.routers.text.verda_service")
-    def test_generate_returns_503_when_unhealthy(
-        self, mock_vs, client, registered_user, auth_headers
-    ):
-        _setup_deployment_discovery(mock_vs, healthy=False)
-
-        response = client.post(
-            "/text/generate",
-            json={"prompt": "Hello", "model_path": TEST_DISPLAY_NAME},
-            headers=auth_headers,
-        )
-
-        assert response.status_code == 503
-        assert "not healthy" in response.json()["detail"].lower()
-        mock_vs.generate_text.assert_not_called()
+    """POST /text/chat must reject when deployment is unhealthy."""
 
     @patch("app.routers.text.verda_service")
     def test_chat_returns_503_when_unhealthy(
@@ -174,27 +158,6 @@ class TestHealthGating:
         assert response.status_code == 503
         assert "not healthy" in response.json()["detail"].lower()
         mock_vs.chat.assert_not_called()
-
-    @patch("app.routers.text.verda_service")
-    def test_generate_proceeds_when_healthy(
-        self, mock_vs, client, registered_user, auth_headers
-    ):
-        _setup_deployment_discovery(mock_vs, healthy=True)
-        mock_vs.generate_text.return_value = {
-            "generated_text": "world",
-            "model": "deepseek-ai/deepseek-llm-7b-chat",
-            "usage": {},
-        }
-
-        response = client.post(
-            "/text/generate",
-            json={"prompt": "Hello", "model_path": TEST_DISPLAY_NAME},
-            headers=auth_headers,
-        )
-
-        assert response.status_code == 200
-        assert response.json()["generated_text"] == "world"
-        mock_vs.generate_text.assert_called_once()
 
     @patch("app.routers.text.verda_service")
     def test_chat_proceeds_when_healthy(
@@ -343,90 +306,12 @@ class TestConnectErrors:
         assert response.json()["healthy"] is True
 
 
-class TestDeleteErrors:
-    """DELETE /text/deploy error paths."""
-
-    @patch("app.routers.text.verda_service")
-    def test_delete_error_returns_500(
-        self, mock_vs, client, admin_registered_user, auth_headers
-    ):
-        mock_vs.delete_deployment.return_value = {
-            "status": "error",
-            "name": "deploy-1",
-            "message": "api failure",
-        }
-
-        response = client.delete("/text/deploy?deployment_name=deploy-1", headers=auth_headers)
-
-        assert response.status_code == 500
-        assert "api failure" in response.json()["detail"]
-
-    @patch("app.routers.text.verda_service")
-    def test_delete_no_deployment_returns_200(
-        self, mock_vs, client, admin_registered_user, auth_headers
-    ):
-        mock_vs.delete_deployment.return_value = {
-            "status": "no_deployment",
-            "message": "No active deployment to delete",
-        }
-
-        response = client.delete("/text/deploy?deployment_name=deploy-1", headers=auth_headers)
-
-        assert response.status_code == 200
-        assert response.json()["status"] == "no_deployment"
-
-    @patch("app.routers.text.verda_service")
-    def test_delete_success_returns_200(
-        self, mock_vs, client, admin_registered_user, auth_headers
-    ):
-        mock_vs.delete_deployment.return_value = {
-            "status": "deleted",
-            "name": "deploy-1",
-        }
-
-        response = client.delete("/text/deploy?deployment_name=deploy-1", headers=auth_headers)
-
-        assert response.status_code == 200
-        assert response.json()["status"] == "deleted"
-
-
 # ===========================================================================
-# 3. MongoDB history inserts for text/generate and text/chat
+# 3. MongoDB history inserts for text/chat
 # ===========================================================================
 
 class TestTextHistoryInserts:
-    """Verify that successful /generate and /chat calls save to MongoDB."""
-
-    @patch("app.routers.text.verda_service")
-    def test_generate_inserts_history_record(
-        self, mock_vs, client, mock_db, registered_user, auth_headers
-    ):
-        _setup_deployment_discovery(mock_vs, healthy=True)
-        mock_vs.generate_text.return_value = {
-            "generated_text": "once upon a time",
-            "model": "deepseek-ai/deepseek-llm-7b-chat",
-            "usage": {"prompt_tokens": 3, "completion_tokens": 5},
-        }
-
-        response = client.post(
-            "/text/generate",
-            json={"prompt": "Tell me a story", "model_path": TEST_DISPLAY_NAME},
-            headers=auth_headers,
-        )
-
-        assert response.status_code == 200
-
-        # Verify MongoDB insert
-        records = list(mock_db.text_generations.find({"type": "text"}))
-        assert len(records) == 1
-
-        rec = records[0]
-        assert rec["prompt"] == "Tell me a story"
-        assert rec["generated_text"] == "once upon a time"
-        assert rec["model"] == "deepseek-ai/deepseek-llm-7b-chat"
-        assert rec["username"] == "testuser"
-        assert "timestamp" in rec
-        assert rec["usage"] == {"prompt_tokens": 3, "completion_tokens": 5}
+    """Verify that successful /chat calls save to MongoDB."""
 
     @patch("app.routers.text.verda_service")
     def test_chat_inserts_history_record(
@@ -457,29 +342,6 @@ class TestTextHistoryInserts:
         assert rec["messages"] == [{"role": "user", "content": "How are you?"}]
         assert "timestamp" in rec
         assert rec["usage"] == {"prompt_tokens": 4, "completion_tokens": 6}
-
-    @patch("app.routers.text.verda_service")
-    def test_generate_still_returns_on_db_failure(
-        self, mock_vs, client, mock_db, registered_user, auth_headers
-    ):
-        """Even if MongoDB insert fails, the endpoint should still return generated text."""
-        _setup_deployment_discovery(mock_vs, healthy=True)
-        mock_vs.generate_text.return_value = {
-            "generated_text": "result",
-            "model": "deepseek-ai/deepseek-llm-7b-chat",
-            "usage": {},
-        }
-
-        # Make the insert blow up
-        with patch.object(mock_db.text_generations, "insert_one", side_effect=Exception("db down")):
-            response = client.post(
-                "/text/generate",
-                json={"prompt": "go", "model_path": TEST_DISPLAY_NAME},
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        assert response.json()["generated_text"] == "result"
 
     @patch("app.routers.text.verda_service")
     def test_chat_still_returns_on_db_failure(
@@ -557,19 +419,11 @@ class TestAuthRequired:
         response = client.get("/text/status?deployment_name=x")
         assert response.status_code == 401
 
-    def test_generate_requires_auth(self, client):
-        response = client.post("/text/generate", json={"prompt": "hi", "model_path": "deepseek-llm-7b"})
-        assert response.status_code == 401
-
     def test_chat_requires_auth(self, client):
         response = client.post(
             "/text/chat",
             json={"model_path": "deepseek-llm-7b", "messages": [{"role": "user", "content": "hi"}]},
         )
-        assert response.status_code == 401
-
-    def test_delete_requires_auth(self, client):
-        response = client.delete("/text/deploy?deployment_name=x")
         assert response.status_code == 401
 
 


### PR DESCRIPTION
Removed several endpoints that were no longer used. The associated tests targeting these endpoints have also been removed or updated accordingly.

### Removed Endpoints

* **POST `/text/generate`**
  Everything is routed through the /text/chat

* **DELETE `/text/deploy`**
  Container teardown is now handled centrally via the admin dashboard:
  `POST /dashboard/containers/{deployment_name}/stop`.

* **GET `/text/available-compute`**
  Unused `check_compute_resources()` wrapper endpoint.

### Currently Unused but retained

The following endpoints are not currently used by the application, but remain in the codebase as they are still referenced by tests and may be needed for upcoming features (e.g., user-managed model deployments):

* `GET /text/status`
* `GET /text/deployments`
* `POST /text/connect`
* `GET /audio/health`

