### PR TITLE
Add support for vision-language models and a new webcam-based analysis.

### DIFF
--- a/gen-ai-playground/backend/app/models.py
+++ b/gen-ai-playground/backend/app/models.py
@@ -293,4 +293,21 @@ class StreamRequest(BaseModel):
     deployment_name: str
     max_tokens: int = Field(default=256, ge=1, le=32768)
     model_path: Optional[str] = None
+
+
+# ---- Vision Models ----
+
+class VisionChatMessage(BaseModel):
+    """A single vision chat message"""
+    role: str  # 'user', 'assistant', or 'system'
+    content: List[Dict[str, Any]]
+
+class VisionChatRequest(BaseModel):
+    """Request model for vision chat completions"""
+    deployment_name: str
+    model_path: Optional[str] = None
+    messages: List[VisionChatMessage]
+    max_tokens: int = 512
+    temperature: float = 0.7
+    top_p: float = 0.9
     enable_thinking: bool = False

--- a/gen-ai-playground/backend/app/routers/vision.py
+++ b/gen-ai-playground/backend/app/routers/vision.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from app.config import settings
-from app.dependencies import get_current_user, get_admin_user, get_container_handler, validate_csrf_token
+from app.dependencies import get_current_user, get_container_handler, validate_csrf_token
 from app.models import UserInfo, VisionChatRequest, DeployModelRequest, DeploymentStatusResponse
 from app.template_discovery import _deployment_name_from_filename, get_vision_template_configs, get_vision_template_map
 from app.verda_service import verda_service
@@ -87,7 +87,7 @@ def get_vision_model_statuses(current_user: UserInfo = Depends(get_current_user)
 @router.post("/deploy", response_model=DeploymentStatusResponse)
 def deploy_vision_model(
     request: DeployModelRequest,
-    current_user: UserInfo = Depends(get_admin_user),
+    current_user: UserInfo = Depends(get_current_user),
     _: None = Depends(validate_csrf_token),
     container_handler: ContainerHandler = Depends(get_container_handler),
 ):

--- a/gen-ai-playground/backend/app/routers/vision.py
+++ b/gen-ai-playground/backend/app/routers/vision.py
@@ -22,12 +22,6 @@ def _inference_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _vision_deployment_names() -> set[str]:
-    return {
-        _deployment_name_from_filename(template_name)
-        for template_name in get_vision_template_map().keys()
-    }
-
 
 def _resolve_vision_template_name(model: str) -> str | None:
     """Resolve a display name or deployment name to a template filename."""

--- a/gen-ai-playground/backend/app/routers/vision.py
+++ b/gen-ai-playground/backend/app/routers/vision.py
@@ -1,9 +1,6 @@
 """Vision endpoints."""
 import json
 import re
-import time
-from typing import Any
-
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse

--- a/gen-ai-playground/backend/app/routers/vision.py
+++ b/gen-ai-playground/backend/app/routers/vision.py
@@ -1,0 +1,249 @@
+"""Vision endpoints."""
+import json
+import re
+import time
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from app.config import settings
+from app.dependencies import get_current_user, get_admin_user, get_container_handler, validate_csrf_token
+from app.models import UserInfo, VisionChatRequest, DeployModelRequest, DeploymentStatusResponse
+from app.template_discovery import _deployment_name_from_filename, get_vision_template_configs, get_vision_template_map
+from app.verda_service import verda_service
+from app.container_handler import ContainerHandler
+
+router = APIRouter(prefix="/vision", tags=["vision"])
+
+
+def _inference_headers() -> dict[str, str]:
+    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _vision_deployment_names() -> set[str]:
+    return {
+        _deployment_name_from_filename(template_name)
+        for template_name in get_vision_template_map().keys()
+    }
+
+
+def _resolve_vision_template_name(model: str) -> str | None:
+    """Resolve a display name or deployment name to a template filename."""
+    model = model.strip()
+    normalized_model = re.sub(r"[^a-z0-9]", "", model.lower())
+    for template_name, display_name in get_vision_template_map().items():
+        normalized_display_name = re.sub(r"[^a-z0-9]", "", display_name.lower())
+        deployment_name = _deployment_name_from_filename(template_name)
+        if display_name == model or template_name == model or deployment_name == model.lower():
+            return template_name
+        if normalized_display_name == normalized_model:
+            return template_name
+    return None
+
+
+@router.get("/models")
+def list_available_vision_models(current_user: UserInfo = Depends(get_current_user)):
+    """List all available vision model templates."""
+    available_models = verda_service.available_models(get_vision_template_map())
+    return {"available_models": available_models}
+
+
+@router.get("/model-statuses")
+def get_vision_model_statuses(current_user: UserInfo = Depends(get_current_user)) -> dict[str, str]:
+    """Return live/starting/offline status for each known vision model."""
+    template_map = get_vision_template_map()
+    statuses: dict[str, str] = {display_name: "offline" for display_name in template_map.values()}
+
+    try:
+        deployments = verda_service.list_deployments()
+    except RuntimeError:
+        return statuses
+
+    template_deployment_map = {
+        _deployment_name_from_filename(template_name): display_name
+        for template_name, display_name in template_map.items()
+    }
+
+    for deployment in deployments:
+        deployment_name = deployment.get("name")
+        if not deployment_name:
+            continue
+
+        display_name = template_deployment_map.get(deployment_name.lower())
+        if not display_name:
+            continue
+
+        try:
+            deployment_status = verda_service.get_deployment_status(deployment_name)
+            status_str = deployment_status.get("status")
+            if status_str == "healthy":
+                statuses[display_name] = "live"
+            elif status_str in {"error", "unknown", "no_deployment"}:
+                statuses[display_name] = "offline"
+            else:
+                statuses[display_name] = "starting"
+        except RuntimeError:
+            statuses[display_name] = "offline"
+
+    return statuses
+
+
+@router.post("/deploy", response_model=DeploymentStatusResponse)
+def deploy_vision_model(
+    request: DeployModelRequest,
+    current_user: UserInfo = Depends(get_admin_user),
+    _: None = Depends(validate_csrf_token),
+    container_handler: ContainerHandler = Depends(get_container_handler),
+):
+    """Deploy a vision model from template."""
+    print(f"User {current_user.username} requesting vision model deployment: {request.model_path}")
+    template = _resolve_vision_template_name(request.model_path)
+    if not template:
+        supported = list(get_vision_template_map().values())
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported vision model: {request.model_path}. Supported models: {supported}",
+        )
+
+    try:
+        result = verda_service.deploy_from_template(
+            template_json=template,
+            deployment_name=request.deployment_name,
+            container_handler=container_handler,
+        )
+        return DeploymentStatusResponse(**result)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/stream")
+async def vision_stream(
+    stream_req: VisionChatRequest,
+    request: Request,
+    current_user: UserInfo = Depends(get_current_user),
+    container_handler: ContainerHandler = Depends(get_container_handler),
+):
+    """
+    Stream vision model generation responses token-by-token using Server-Sent Events (SSE).
+    """
+    model_path = stream_req.model_path
+    deployment_name = stream_req.deployment_name
+    max_tokens = stream_req.max_tokens
+
+    # Resolve the model_path and deployment_name from the display name if needed
+    template_name = _resolve_vision_template_name(deployment_name)
+    if template_name:
+        expected_dep = _deployment_name_from_filename(template_name)
+        cfg = get_vision_template_configs().get(template_name)
+        if cfg and not model_path:
+            model_path = cfg.model
+    else:
+        # Fallback: try to resolve model_path from the deployment name directly
+        deployment_to_model_path = {
+            _deployment_name_from_filename(tn): cfg.model
+            for tn, cfg in get_vision_template_configs().items()
+        }
+        resolved = deployment_to_model_path.get(deployment_name.lower())
+        if resolved:
+            model_path = resolved
+        expected_dep = deployment_name.lower()
+
+    if not model_path:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Could not resolve model_path for deployment '{deployment_name}'. "
+                "Provide model_path in request body or ensure deployment name matches a known template."
+            ),
+        )
+
+    messages = [m.model_dump() for m in stream_req.messages]
+
+    # Find the running deployment
+    try:
+        deployments = verda_service.list_deployments()
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Could not reach deployment service.",
+        )
+
+    existing = None
+    for d in deployments:
+        if d.get("name", "").lower() == expected_dep:
+            existing = d
+            break
+
+    if not existing:
+        dep_names = [d.get("name", "?") for d in deployments]
+        raise HTTPException(
+            status_code=503,
+            detail=f"Vision model '{deployment_name}' is not deployed. Available deployments: {dep_names}",
+        )
+
+    deployment_name = existing["name"]
+    container_handler.set_latest_request_timestamp(deployment_name)
+
+    base_url = (existing.get("endpoint_url", "") or "").rstrip("/")
+    if not base_url:
+        raise HTTPException(status_code=503, detail="Deployment endpoint URL is missing")
+
+    normalized_base_url = base_url[:-3] if base_url.endswith("/v1") else base_url
+    target_url = f"{normalized_base_url}/v1/chat/completions"
+
+    request_payload = {
+        "model": model_path,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": stream_req.temperature,
+        "top_p": stream_req.top_p,
+        "stream": True,
+    }
+
+    upstream_timeout = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=5.0)
+
+    print(f"Vision stream: target_url={target_url} model_path={model_path} deployment={expected_dep}", flush=True)
+
+    async def chunk_generator():
+        print("Vision stream: chunk_generator started", flush=True)
+        try:
+            async with httpx.AsyncClient(timeout=upstream_timeout) as async_client:
+                async with async_client.stream(
+                    "POST",
+                    target_url,
+                    json=request_payload,
+                    headers=_inference_headers(),
+                ) as upstream_response:
+                    print(f"Vision stream upstream: status={upstream_response.status_code} url={target_url}", flush=True)
+
+                    if upstream_response.status_code != 200:
+                        err_text = await upstream_response.aread()
+                        error_detail = err_text.decode("utf-8", errors="replace")
+                        print(f"Vision stream upstream error: status={upstream_response.status_code} body={error_detail[:500]}", flush=True)
+                        yield f"data: {json.dumps({'error': error_detail})}\n\n"
+                        return
+
+                    chunk_count = 0
+                    async for chunk in upstream_response.aiter_lines():
+                        if await request.is_disconnected():
+                            print("Vision stream: client disconnected", flush=True)
+                            break
+                        if chunk:
+                            if chunk_count < 3:
+                                print(f"Vision stream upstream chunk[{chunk_count}]: {chunk[:200]}", flush=True)
+                            chunk_count += 1
+                            yield chunk + "\n\n"
+                    print(f"Vision stream upstream: done, total chunks={chunk_count}", flush=True)
+        except httpx.RequestError as e:
+            print(f"Vision stream upstream connection error: {e}", flush=True)
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+        except Exception as e:
+            print(f"Vision stream unexpected error: {e}", flush=True)
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
+    return StreamingResponse(chunk_generator(), media_type="text/event-stream")

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -27,8 +27,12 @@ def _is_video_template(filename: str) -> bool:
     return filename.startswith("video-")
 
 
+def _is_vision_template(filename: str) -> bool:
+    return filename.startswith("vision-")
+
+
 def _is_text_template(filename: str) -> bool:
-    return not _is_audio_template(filename) and not _is_video_template(filename)
+    return not _is_audio_template(filename) and not _is_video_template(filename) and not _is_vision_template(filename)
 
 
 def _display_name_from_filename(filename: str) -> str:
@@ -131,10 +135,17 @@ def discover_video_templates() -> dict[str, str]:
     return names
 
 
+def discover_vision_templates() -> dict[str, str]:
+    names, _configs = _discover_templates_with_predicate(_is_vision_template)
+    return names
+
+
 _cache: dict[str, str] | None = None
 _config_cache: dict[str, TemplateConfig] | None = None
 _audio_cache: dict[str, str] | None = None
 _video_cache: dict[str, str] | None = None
+_vision_cache: dict[str, str] | None = None
+_vision_config_cache: dict[str, TemplateConfig] | None = None
 
 
 def _ensure_cache() -> None:
@@ -171,12 +182,32 @@ def get_video_template_map() -> dict[str, str]:
     return _video_cache
 
 
+def get_vision_template_map() -> dict[str, str]:
+    global _vision_cache, _vision_config_cache
+    if _vision_cache is None:
+        _vision_cache, _vision_config_cache = _discover_templates_with_predicate(
+            _is_vision_template
+        )
+    return _vision_cache
+
+
+def get_vision_template_configs() -> dict[str, TemplateConfig]:
+    """Return cached {template_filename: TemplateConfig} mapping for vision templates."""
+    global _vision_cache, _vision_config_cache
+    if _vision_cache is None:
+        _vision_cache, _vision_config_cache = _discover_templates_with_predicate(
+            _is_vision_template
+        )
+    return _vision_config_cache  # type: ignore[return-value]
+
+
 def refresh() -> dict[str, str]:
     """Re-scan the templates directory and update all caches."""
-    global _cache, _config_cache, _audio_cache, _video_cache
+    global _cache, _config_cache, _audio_cache, _video_cache, _vision_cache
     _cache, _config_cache = _discover_templates_with_predicate(
         _is_text_template
     )
     _audio_cache = discover_audio_templates()
     _video_cache = discover_video_templates()
+    _vision_cache = discover_vision_templates()
     return _cache

--- a/gen-ai-playground/backend/app/template_discovery.py
+++ b/gen-ai-playground/backend/app/template_discovery.py
@@ -184,7 +184,7 @@ def get_video_template_map() -> dict[str, str]:
 
 def get_vision_template_map() -> dict[str, str]:
     global _vision_cache, _vision_config_cache
-    if _vision_cache is None:
+    if _vision_cache is None or _vision_config_cache is None:
         _vision_cache, _vision_config_cache = _discover_templates_with_predicate(
             _is_vision_template
         )
@@ -194,7 +194,7 @@ def get_vision_template_map() -> dict[str, str]:
 def get_vision_template_configs() -> dict[str, TemplateConfig]:
     """Return cached {template_filename: TemplateConfig} mapping for vision templates."""
     global _vision_cache, _vision_config_cache
-    if _vision_cache is None:
+    if _vision_cache is None or _vision_config_cache is None:
         _vision_cache, _vision_config_cache = _discover_templates_with_predicate(
             _is_vision_template
         )
@@ -203,11 +203,13 @@ def get_vision_template_configs() -> dict[str, TemplateConfig]:
 
 def refresh() -> dict[str, str]:
     """Re-scan the templates directory and update all caches."""
-    global _cache, _config_cache, _audio_cache, _video_cache, _vision_cache
+    global _cache, _config_cache, _audio_cache, _video_cache, _vision_cache, _vision_config_cache
     _cache, _config_cache = _discover_templates_with_predicate(
         _is_text_template
     )
     _audio_cache = discover_audio_templates()
     _video_cache = discover_video_templates()
-    _vision_cache = discover_vision_templates()
+    _vision_cache, _vision_config_cache = _discover_templates_with_predicate(
+        _is_vision_template
+    )
     return _cache

--- a/gen-ai-playground/backend/app/template_models.py
+++ b/gen-ai-playground/backend/app/template_models.py
@@ -96,7 +96,7 @@ class TemplateConfig(BaseModel):
     display_name: Optional[str] = None
     explanation: Optional[str] = None
     short_explanation: Optional[str] = None
-    model_mode: Optional[Literal["thinking", "hybrid", "instruct"]] = None
+    model_mode: Optional[Literal["thinking", "hybrid", "instruct", "vision"]] = None
     trust_remote_code: Optional[bool] = None
     quantization: Optional[str] = None
     gpu_types: List[str] = Field(default_factory=list)

--- a/gen-ai-playground/backend/server.py
+++ b/gen-ai-playground/backend/server.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from app.config import settings
-from app.routers import auth, images, text, dashboard, invitations, audio, video
+from app.routers import auth, images, text, dashboard, invitations, audio, video, vision
 from app.container_handler import ContainerHandler
 
 
@@ -52,6 +52,7 @@ app.include_router(dashboard.router)
 app.include_router(invitations.router)
 app.include_router(audio.router)
 app.include_router(video.router)
+app.include_router(vision.router)
 
 
 @app.get("/")

--- a/gen-ai-playground/backend/templates/vision-qwen3-vl-sglang.json
+++ b/gen-ai-playground/backend/templates/vision-qwen3-vl-sglang.json
@@ -1,0 +1,14 @@
+{
+  "engine": "sglang",
+  "model": "Qwen/Qwen3-VL-8B-Instruct",
+  "display_name": "Qwen3 VL 8B · SGLang",
+  "explanation": "Qwen3 VL model for vision-language tasks.",
+  "short_explanation": "Qwen3 VL SGLang",
+  "gpu_types": ["b200", "h100", "h200"],
+  "trust_remote_code": true,
+  "model_mode": "vision",
+  "sglang": {
+    "tp": 1,
+    "chat_template": "qwen2-vl"
+  }
+}

--- a/gen-ai-playground/backend/tests/test_templates_vision_scope.py
+++ b/gen-ai-playground/backend/tests/test_templates_vision_scope.py
@@ -1,0 +1,32 @@
+"""Vision template discovery cache regression tests."""
+
+import json
+from pathlib import Path
+
+from app import template_discovery
+
+
+def test_vision_refresh_rebuilds_config_cache(tmp_path: Path, monkeypatch):
+    template = {
+        "engine": "custom",
+        "display_name": "Vision A",
+        "model": "vision-model-v1",
+        "gpu_types": ["l40s"],
+        "custom": {"image": "repo/vision:v1"},
+        "port": 9000,
+    }
+    template_path = tmp_path / "vision-a.json"
+    template_path.write_text(json.dumps(template), encoding="utf-8")
+
+    monkeypatch.setattr(template_discovery, "TEMPLATES_DIR", tmp_path)
+    monkeypatch.setattr(template_discovery, "_vision_cache", None)
+    monkeypatch.setattr(template_discovery, "_vision_config_cache", None)
+
+    assert template_discovery.get_vision_template_configs()["vision-a.json"].model == "vision-model-v1"
+
+    template["model"] = "vision-model-v2"
+    template_path.write_text(json.dumps(template), encoding="utf-8")
+
+    template_discovery.refresh()
+
+    assert template_discovery.get_vision_template_configs()["vision-a.json"].model == "vision-model-v2"

--- a/gen-ai-playground/backend/tests/test_vision.py
+++ b/gen-ai-playground/backend/tests/test_vision.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import bcrypt
+import jwt
+import mongomock
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.container_handler import ContainerHandler
+from server import app
+
+
+@pytest.fixture
+def mock_db():
+    client = mongomock.MongoClient()
+    return client["gen_ai_playground"]
+
+
+@pytest.fixture
+def regular_user(mock_db):
+    hashed = bcrypt.hashpw(b"UserPass123!", bcrypt.gensalt())
+    mock_db.users.insert_one(
+        {
+            "username": "regularuser",
+            "password": hashed,
+            "is_admin": False,
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+    return {"username": "regularuser", "password": "UserPass123!"}
+
+
+@pytest.fixture
+def auth_headers(regular_user):
+    payload = {
+        "username": regular_user["username"],
+        "exp": datetime.now(timezone.utc) + timedelta(hours=24),
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(mock_db):
+    app.state.container_handler = ContainerHandler()
+    with patch("app.database.db_manager.db", mock_db):
+        with patch("app.database.get_database", return_value=mock_db):
+            yield TestClient(app)
+
+
+@patch("app.routers.vision.get_vision_template_map", return_value={"vision-a.json": "Vision A"})
+@patch("app.routers.vision.verda_service")
+def test_vision_deploy_allows_regular_user(mock_verda_service, _mock_template_map, client, auth_headers):
+    mock_verda_service.deploy_from_template.return_value = {
+        "name": "vision-a",
+        "status": "deploying",
+        "model": "vision-model-v1",
+    }
+
+    response = client.post(
+        "/vision/deploy",
+        json={"model_path": "Vision A"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "vision-a"
+    mock_verda_service.deploy_from_template.assert_called_once_with(
+        template_json="vision-a.json",
+        deployment_name=None,
+        container_handler=app.state.container_handler,
+    )

--- a/gen-ai-playground/frontend/src/components/TextGenerator.tsx
+++ b/gen-ai-playground/frontend/src/components/TextGenerator.tsx
@@ -19,6 +19,7 @@ import {
 import { useMediaQuery } from "@mantine/hooks"
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
+import { modelStatusPriority, type ModelStatus } from "../utils/types"
 import { ShareConversationModal } from "./SharedConversationsModal"
 import { fetchTextModels, fetchTextModelStatuses, fetchTextDeployments } from "../services/textService"
 import { deployTextModel} from "../services/dashboardService"
@@ -45,8 +46,6 @@ type Message = {
 }
 
 
-type ModelStatus = "live" | "starting" | "offline" | "unknown"
-
 const makeMessageId = () => {
   // Prefer crypto.randomUUID when available; fall back for older browsers.
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -56,13 +55,6 @@ const makeMessageId = () => {
 }
 
 const MAX_MODELS = 4
-
-const modelStatusPriority: Record<ModelStatus, number> = {
-  live: 0,
-  starting: 1,
-  unknown: 2,
-  offline: 3,
-}
 
 // Build dropdown data with colored status dots; disable non-live models
 function buildDropdownData(modelOptions: ModelOption[], statuses: Record<string, ModelStatus>) {

--- a/gen-ai-playground/frontend/src/components/Transcribe.tsx
+++ b/gen-ai-playground/frontend/src/components/Transcribe.tsx
@@ -3,6 +3,7 @@ import { Alert, Button, FileInput, MultiSelect, Text, Textarea } from "@mantine/
 
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
+import { modelStatusPriority, type ModelStatus } from "../utils/types"
 import { formatAudioModelName } from "./history-ui/audioHistoryUtils"
 import {
   fetchAudioModels as fetchAudioModelsRequest,
@@ -30,7 +31,6 @@ type TranscriptionResponse = {
 }
 
 type TranscribeSource = "uploaded" | "recording"
-type ModelStatus = "live" | "starting" | "offline" | "unknown"
 
 type ModelOption = {
   value: string
@@ -46,13 +46,6 @@ type ModelTranscriptionState = {
 }
 
 const MAX_AUDIO_MODELS = 4
-
-const modelStatusPriority: Record<ModelStatus, number> = {
-  live: 0,
-  starting: 1,
-  unknown: 2,
-  offline: 3,
-}
 
 function buildDropdownData(modelOptions: ModelOption[], statuses: Record<string, ModelStatus>) {
   return modelOptions

--- a/gen-ai-playground/frontend/src/components/VideoGenerator.tsx
+++ b/gen-ai-playground/frontend/src/components/VideoGenerator.tsx
@@ -5,6 +5,7 @@ import { notifications } from "@mantine/notifications"
 
 import ActionStatus from "./ActionStatus"
 import { formatDurationMs } from "../utils/time"
+import { modelStatusPriority } from "../utils/types"
 import {
   fetchVideoModels,
   fetchVideoModelStatuses,
@@ -16,15 +17,6 @@ import {
 import { deployVideoModel } from "../services/dashboardService"
 import { useDeployModel } from "../hooks/useDeployModel"
 import { useAuth } from "../context/AuthContext"
-
-type ModelStatus = "live" | "starting" | "offline" | "unknown"
-
-const modelStatusPriority: Record<ModelStatus, number> = {
-  live: 0,
-  starting: 1,
-  unknown: 2,
-  offline: 3,
-}
 
 function buildDropdownData(modelOptions: VideoModelApiItem[], statuses: VideoModelStatuses) {
   return modelOptions

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -4,18 +4,10 @@ import { streamVision, type VisionChatMessagePayload, fetchVisionModels, fetchVi
 import { deployVisionModel } from "../services/dashboardService"
 import { useDeployModel } from "../hooks/useDeployModel"
 import { useAuth } from "../context/AuthContext"
+import { modelStatusPriority } from "../utils/types"
 
 interface WebcamAIAnalysisProps {
   opened?: boolean
-}
-
-type ModelStatus = "live" | "starting" | "offline" | "unknown"
-
-const modelStatusPriority: Record<ModelStatus, number> = {
-  live: 0,
-  starting: 1,
-  unknown: 2,
-  offline: 3,
 }
 
 function buildDropdownData(modelOptions: VisionModelApiItem[], statuses: VisionModelStatuses) {

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -37,7 +37,7 @@ function buildDropdownData(modelOptions: VisionModelApiItem[], statuses: VisionM
     })
 }
 
-export default function WebcamAIAnalysis({}: WebcamAIAnalysisProps) {
+export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
   const [isActive, setIsActive] = useState(false)
   const [output, setOutput] = useState<string>("")
   const [modelOptions, setModelOptions] = useState<VisionModelApiItem[]>([])

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -45,8 +45,6 @@ export default function WebcamAIAnalysis({ opened }: WebcamAIAnalysisProps) {
   const streamRef = useRef<MediaStream | null>(null)
   const loopRef = useRef<boolean>(false)
   const mountedRef = useRef<boolean>(true)
-  const selectedModelRef = useRef<string | null>(null)
-
   const fetchModels = useCallback(async () => {
     try {
       const models = await fetchVisionModels()
@@ -74,11 +72,6 @@ export default function WebcamAIAnalysis({ opened }: WebcamAIAnalysisProps) {
     const intervalId = window.setInterval(fetchStatuses, 30000)
     return () => window.clearInterval(intervalId)
   }, [fetchStatuses])
-
-  // Keep ref in sync with selectedModel for unmount cleanup
-  useEffect(() => {
-    selectedModelRef.current = selectedModel
-  }, [selectedModel])
 
   // Auto-select first live model
   useEffect(() => {

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -1,0 +1,333 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
+import { Box, Group, Paper, Text, ScrollArea, Switch, Select, Button, Alert, Stack, Slider } from "@mantine/core"
+import { streamVision, type VisionChatMessagePayload, fetchVisionModels, fetchVisionModelStatuses, type VisionModelApiItem, type VisionModelStatuses } from "../services/visionService"
+import { deployVisionModel, stopDashboardContainer } from "../services/dashboardService"
+import { useDeployModel } from "../hooks/useDeployModel"
+import { useAuth } from "../context/AuthContext"
+
+interface WebcamAIAnalysisProps {
+  opened?: boolean
+}
+
+type ModelStatus = "live" | "starting" | "offline" | "unknown"
+
+const modelStatusPriority: Record<ModelStatus, number> = {
+  live: 0,
+  starting: 1,
+  unknown: 2,
+  offline: 3,
+}
+
+function buildDropdownData(modelOptions: VisionModelApiItem[], statuses: VisionModelStatuses) {
+  return modelOptions
+    .map(model => {
+      const status = statuses[model.value] ?? "unknown"
+      const emoji = status === "live" ? "\u{1F7E2}" : status === "starting" ? "\u{1F7E1}" : "\u26AA"
+      return {
+        value: model.value,
+        label: `${emoji} ${model.label}`,
+      }
+    })
+    .sort((a, b) => {
+      const leftStatus = statuses[a.value] ?? "unknown"
+      const rightStatus = statuses[b.value] ?? "unknown"
+      const statusDiff = modelStatusPriority[leftStatus] - modelStatusPriority[rightStatus]
+      if (statusDiff !== 0) return statusDiff
+      return a.label.localeCompare(b.label)
+    })
+}
+
+export default function WebcamAIAnalysis({}: WebcamAIAnalysisProps) {
+  const [isActive, setIsActive] = useState(false)
+  const [output, setOutput] = useState<string>("")
+  const [modelOptions, setModelOptions] = useState<VisionModelApiItem[]>([])
+  const [modelStatuses, setModelStatuses] = useState<VisionModelStatuses>({})
+  const [selectedModel, setSelectedModel] = useState<string | null>(null)
+  const [intervalMs, setIntervalMs] = useState(5000)
+  const prompt = "Describe what you see in this image in detail."
+
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const loopRef = useRef<boolean>(false)
+  const mountedRef = useRef<boolean>(true)
+  const selectedModelRef = useRef<string | null>(null)
+
+  const fetchModels = useCallback(async () => {
+    try {
+      const models = await fetchVisionModels()
+      setModelOptions(models)
+    } catch {
+      setModelOptions([])
+    }
+  }, [])
+
+  const fetchStatuses = useCallback(async () => {
+    try {
+      const statuses = await fetchVisionModelStatuses()
+      setModelStatuses(statuses)
+    } catch {
+      setModelStatuses({})
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchModels()
+    fetchStatuses()
+  }, [fetchModels, fetchStatuses])
+
+  useEffect(() => {
+    const intervalId = window.setInterval(fetchStatuses, 30000)
+    return () => window.clearInterval(intervalId)
+  }, [fetchStatuses])
+
+  // Keep ref in sync with selectedModel for unmount cleanup
+  useEffect(() => {
+    selectedModelRef.current = selectedModel
+  }, [selectedModel])
+
+  // Auto-select first live model
+  useEffect(() => {
+    if (selectedModel) return
+    const liveModel = modelOptions.find(model => modelStatuses[model.value] === "live")
+    if (liveModel) setSelectedModel(liveModel.value)
+  }, [modelOptions, modelStatuses, selectedModel])
+
+  const dropdownData = useMemo(
+    () => buildDropdownData(modelOptions, modelStatuses),
+    [modelOptions, modelStatuses],
+  )
+
+  const selectedStatus = selectedModel ? modelStatuses[selectedModel] ?? "unknown" : null
+  const canAnalyze = !!selectedModel && selectedStatus === "live"
+
+  const { isLoggedIn } = useAuth()
+  const visionService = useMemo(() => ({
+    fetchOptions: async () => {
+      const models = await fetchVisionModels()
+      return models.map(m => ({ value: m.value, label: m.label }))
+    },
+    deploy: async (modelPath: string) => {
+      await deployVisionModel(modelPath)
+    },
+    fetchStatuses: async () => {
+      const statuses = await fetchVisionModelStatuses()
+      setModelStatuses(statuses)
+    }
+  }), [])
+
+  const visionDeploy = useDeployModel(isLoggedIn, visionService)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      stopWebcam()
+      const model = selectedModelRef.current
+      if (model) {
+        stopDashboardContainer(model).catch(err =>
+          console.error("Failed to stop model on unmount:", err)
+        )
+      }
+    }
+  }, [])
+
+  const startWebcam = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true })
+      streamRef.current = stream
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream
+        videoRef.current.play()
+      }
+      setIsActive(true)
+      loopRef.current = true
+      runAnalysisLoop()
+    } catch (err) {
+      console.error("Failed to access webcam:", err)
+    }
+  }
+
+  const stopWebcam = () => {
+    setIsActive(false)
+    loopRef.current = false
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current = null
+    }
+  }
+
+  const grabFrame = (): string | null => {
+    const video = videoRef.current
+    const canvas = canvasRef.current
+    if (!video || !canvas || video.videoWidth === 0 || video.videoHeight === 0) return null
+
+    if (canvas.width !== video.videoWidth || canvas.height !== video.videoHeight) {
+      canvas.width = video.videoWidth
+      canvas.height = video.videoHeight
+    }
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return null
+
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+    return canvas.toDataURL("image/jpeg", 0.6)
+  }
+
+  const runAnalysisLoop = async () => {
+    if (!loopRef.current) return
+
+    const base64Image = grabFrame()
+    if (!base64Image) {
+      setTimeout(runAnalysisLoop, intervalMs)
+      return
+    }
+
+    const messages: VisionChatMessagePayload[] = [
+      {
+        role: "user",
+        content: [
+          { type: "image_url", image_url: { url: base64Image } },
+          { type: "text", text: prompt }
+        ]
+      }
+    ]
+
+    try {
+      setOutput("")
+
+      console.log("[Vision] Starting stream request...")
+      const iterator = await streamVision({
+        deployment_name: selectedModel || "",
+        messages,
+        max_tokens: 256,
+        temperature: 0.1
+      }, loopRef)
+      console.log("[Vision] Got iterator, starting to read chunks...")
+
+      let currentReply = ""
+      let chunkCount = 0
+      for await (const chunk of iterator) {
+        if (!loopRef.current) break
+        chunkCount++
+        if (chunkCount <= 3) {
+          console.log(`[Vision] chunk[${chunkCount}]:`, chunk.substring(0, 80))
+        }
+        currentReply += chunk
+        setOutput(currentReply)
+      }
+      console.log(`[Vision] Stream ended, total chunks: ${chunkCount}, reply length: ${currentReply.length}`)
+    } catch (e) {
+      console.error("[Vision] Stream failed", e)
+      setOutput(`Error: ${e instanceof Error ? e.message : String(e)}`)
+    }
+
+    if (loopRef.current) {
+      setTimeout(runAnalysisLoop, intervalMs)
+    }
+  }
+
+  return (
+    <Stack maw={1200} mx="auto" p="md" gap="md">
+      <Text c="dimmed" size="sm">
+        Connect your webcam and use a vision-language model to describe the live feed.
+      </Text>
+
+      <Text size="sm" fw={500}>Analysis Interval ({intervalMs / 1000}s)</Text>
+      <Slider
+        value={intervalMs}
+        onChange={setIntervalMs}
+        min={1000}
+        max={30000}
+        step={1000}
+        disabled={isActive}
+        marks={[
+          { value: 1000, label: "1s" },
+          { value: 5000, label: "5s" },
+          { value: 10000, label: "10s" },
+          { value: 20000, label: "20s" },
+          { value: 30000, label: "30s" },
+        ]}
+      />
+
+      <Select
+        label="Model"
+        placeholder="Select a live vision model"
+        data={dropdownData}
+        value={selectedModel}
+        onChange={next => {
+          const liveOnly = next && (modelStatuses[next] ?? "unknown") === "live" ? next : null
+          setSelectedModel(liveOnly)
+        }}
+        searchable
+        clearable
+        disabled={isActive}
+        renderOption={({ option }) => (
+          <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+            <span>{option.label}</span>
+            {(modelStatuses[option.value] ?? "unknown") !== "live" ? (
+              <Button
+                type="button"
+                variant="filled"
+                size="xs"
+                color="green"
+                loading={visionDeploy.isDeploying(option.value)}
+                disabled={visionDeploy.isDeploying(option.value) || (modelStatuses[option.value] ?? "unknown") === "starting"}
+                onClick={visionDeploy.handleDeployModel(option.value)}
+              >
+                Start model
+              </Button>
+            ) : null}
+          </div>
+        )}
+      />
+
+      {selectedModel && selectedStatus !== "live" ? (
+        <Alert color={selectedStatus === "starting" ? "yellow" : "gray"} variant="light">
+          {selectedStatus === "starting"
+            ? "This model is starting up. Please wait and try again."
+            : "This model is not live. Ask an admin to deploy it from the dashboard."}
+        </Alert>
+      ) : null}
+
+      <Group mb="md" style={{ justifyContent: 'space-between' }}>
+        <Text size="xl" style={{ fontWeight: 'bold' }}>Live Webcam Feed</Text>
+        <Switch
+          label="Enable Analysis"
+          checked={isActive}
+          disabled={!canAnalyze && !isActive}
+          onChange={(e) => e.currentTarget.checked ? startWebcam() : stopWebcam()}
+        />
+      </Group>
+
+      <Group grow style={{ flex: 1, alignItems: 'flex-start' }} align="flex-start">
+        <Paper shadow="sm" p="md" withBorder style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <Text mb="sm" fw={500}>Webcam Feed</Text>
+          <Box style={{ position: 'relative', width: '100%', paddingBottom: '75%', backgroundColor: '#000', borderRadius: '8px', overflow: 'hidden' }}>
+            <video
+              ref={videoRef}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover'
+              }}
+              muted
+              playsInline
+            />
+            <canvas ref={canvasRef} style={{ display: "none" }} />
+          </Box>
+        </Paper>
+
+        <Paper shadow="sm" p="md" withBorder style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: '300px' }}>
+          <Text mb="sm" fw={500}>Live Analysis</Text>
+          <ScrollArea style={{ flex: 1, backgroundColor: '#f8f9fa', padding: '16px', borderRadius: '4px' }}>
+            {output || <Text c="dimmed">Waiting for feed...</Text>}
+          </ScrollArea>
+        </Paper>
+      </Group>
+    </Stack>
+  )
+}

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Box, Group, Paper, Text, ScrollArea, Switch, Select, Button, Alert, Stack, Slider } from "@mantine/core"
 import { streamVision, type VisionChatMessagePayload, fetchVisionModels, fetchVisionModelStatuses, type VisionModelApiItem, type VisionModelStatuses } from "../services/visionService"
-import { deployVisionModel, stopDashboardContainer } from "../services/dashboardService"
+import { deployVisionModel } from "../services/dashboardService"
 import { useDeployModel } from "../hooks/useDeployModel"
 import { useAuth } from "../context/AuthContext"
 
@@ -37,7 +37,9 @@ function buildDropdownData(modelOptions: VisionModelApiItem[], statuses: VisionM
     })
 }
 
-export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
+export default function WebcamAIAnalysis({ opened }: WebcamAIAnalysisProps) {
+  void opened
+
   const [isActive, setIsActive] = useState(false)
   const [output, setOutput] = useState<string>("")
   const [modelOptions, setModelOptions] = useState<VisionModelApiItem[]>([])
@@ -101,7 +103,7 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
   const selectedStatus = selectedModel ? modelStatuses[selectedModel] ?? "unknown" : null
   const canAnalyze = !!selectedModel && selectedStatus === "live"
 
-  const { isLoggedIn, isAdmin } = useAuth()
+  const { isLoggedIn } = useAuth()
   const visionService = useMemo(() => ({
     fetchOptions: async () => {
       const models = await fetchVisionModels()

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -101,7 +101,7 @@ export default function WebcamAIAnalysis({}: WebcamAIAnalysisProps) {
   const selectedStatus = selectedModel ? modelStatuses[selectedModel] ?? "unknown" : null
   const canAnalyze = !!selectedModel && selectedStatus === "live"
 
-  const { isLoggedIn } = useAuth()
+  const { isLoggedIn, isAdmin } = useAuth()
   const visionService = useMemo(() => ({
     fetchOptions: async () => {
       const models = await fetchVisionModels()

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -89,7 +89,7 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
   // Auto-select first live model
   useEffect(() => {
     if (selectedModel) return
-    const liveModel = modelOptions.find(model => modelStatuses[model.value] === "live")
+    const liveModel = modelOptions.find((model: VisionModelApiItem) => modelStatuses[model.value] === "live")
     if (liveModel) setSelectedModel(liveModel.value)
   }, [modelOptions, modelStatuses, selectedModel])
 
@@ -148,7 +148,7 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
     setIsActive(false)
     loopRef.current = false
     if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current.getTracks().forEach((track: MediaStreamTrack) => track.stop())
       streamRef.current = null
     }
   }
@@ -246,14 +246,14 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
         placeholder="Select a live vision model"
         data={dropdownData}
         value={selectedModel}
-        onChange={next => {
+        onChange={(next: string | null) => {
           const liveOnly = next && (modelStatuses[next] ?? "unknown") === "live" ? next : null
           setSelectedModel(liveOnly)
         }}
         searchable
         clearable
         disabled={isActive}
-        renderOption={({ option }) => (
+        renderOption={({ option }: { option: { label: string; value: string } }) => (
           <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
             <span>{option.label}</span>
             {(modelStatuses[option.value] ?? "unknown") !== "live" ? (
@@ -277,7 +277,7 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
         <Alert color={selectedStatus === "starting" ? "yellow" : "gray"} variant="light">
           {selectedStatus === "starting"
             ? "This model is starting up. Please wait and try again."
-            : "This model is not live. Ask an admin to deploy it from the dashboard."}
+            : "This model is not live yet. Start it from here and wait for it to boot."}
         </Alert>
       ) : null}
 
@@ -287,7 +287,7 @@ export default function WebcamAIAnalysis(_props: WebcamAIAnalysisProps) {
           label="Enable Analysis"
           checked={isActive}
           disabled={!canAnalyze && !isActive}
-          onChange={(e) => e.currentTarget.checked ? startWebcam() : stopWebcam()}
+          onChange={(e: { currentTarget: { checked: boolean } }) => e.currentTarget.checked ? startWebcam() : stopWebcam()}
         />
       </Group>
 

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -192,27 +192,22 @@ export default function WebcamAIAnalysis({}: WebcamAIAnalysisProps) {
     try {
       setOutput("")
 
-      console.log("[Vision] Starting stream request...")
-      const iterator = await streamVision({
-        deployment_name: selectedModel || "",
-        messages,
-        max_tokens: 256,
-        temperature: 0.1
-      }, loopRef)
-      console.log("[Vision] Got iterator, starting to read chunks...")
+      const iterator = await streamVision(
+        {
+          deployment_name: selectedModel || "",
+          messages,
+          max_tokens: 256,
+          temperature: 0.1,
+        },
+        loopRef,
+      )
 
       let currentReply = ""
-      let chunkCount = 0
       for await (const chunk of iterator) {
         if (!loopRef.current) break
-        chunkCount++
-        if (chunkCount <= 3) {
-          console.log(`[Vision] chunk[${chunkCount}]:`, chunk.substring(0, 80))
-        }
         currentReply += chunk
         setOutput(currentReply)
       }
-      console.log(`[Vision] Stream ended, total chunks: ${chunkCount}, reply length: ${currentReply.length}`)
     } catch (e) {
       console.error("[Vision] Stream failed", e)
       setOutput(`Error: ${e instanceof Error ? e.message : String(e)}`)

--- a/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
+++ b/gen-ai-playground/frontend/src/components/WebcamAIAnalysis.tsx
@@ -123,12 +123,8 @@ export default function WebcamAIAnalysis({}: WebcamAIAnalysisProps) {
     return () => {
       mountedRef.current = false
       stopWebcam()
-      const model = selectedModelRef.current
-      if (model) {
-        stopDashboardContainer(model).catch(err =>
-          console.error("Failed to stop model on unmount:", err)
-        )
-      }
+      // Do not stop deployments automatically on unmount; deployments are admin-managed/shared.
+
     }
   }, [])
 

--- a/gen-ai-playground/frontend/src/constants/tabs.ts
+++ b/gen-ai-playground/frontend/src/constants/tabs.ts
@@ -1,5 +1,5 @@
 // Shared constants for playground tabs
-export const PLAYGROUND_TABS = ['ImageGenerator', 'ImageEditor', 'TextGenerator', 'Transcribe', 'VideoGenerator'] as const
+export const PLAYGROUND_TABS = ['ImageGenerator', 'ImageEditor', 'TextGenerator', 'Transcribe', 'VideoGenerator', 'WebcamAnalysis'] as const
 
 export type PlaygroundTab = typeof PLAYGROUND_TABS[number]
 

--- a/gen-ai-playground/frontend/src/pages/DashboardContainers.tsx
+++ b/gen-ai-playground/frontend/src/pages/DashboardContainers.tsx
@@ -4,10 +4,12 @@ import {
   deployAudioModel,
   deployTextModel,
   deployVideoModel,
+  deployVisionModel,
   fetchDashboardContainers,
   fetchDeployableAudioModels,
   fetchDeployableTextModels,
   fetchDeployableVideoModels,
+  fetchDeployableVisionModels,
   stopDashboardContainer,
 } from "../services/dashboardService"
 import {
@@ -38,7 +40,7 @@ interface DeployOption {
   id: string
   modelPath: string
   label: string
-  kind: "text" | "audio" | "video"
+  kind: "text" | "audio" | "video" | "vision"
 }
 
 export default function DashboardContainers() {
@@ -52,6 +54,7 @@ export default function DashboardContainers() {
   const [textOpen, setTextOpen] = useState(true)
   const [audioOpen, setAudioOpen] = useState(true)
   const [videoOpen, setVideoOpen] = useState(true)
+  const [visionOpen, setVisionOpen] = useState(true)
 
   const isMobile = useMediaQuery("(max-width: 768px)")
   const textModels = deployOptions
@@ -63,6 +66,9 @@ export default function DashboardContainers() {
   const videoModels = deployOptions
     .filter(m => m.kind === "video")
     .map(m => ({ id: m.id, label: m.label.replace("Video: ", "") }))
+  const visionModels = deployOptions
+    .filter(m => m.kind === "vision")
+    .map(m => ({ id: m.id, label: m.label.replace("Vision: ", "") }))
 
   useEffect(() => {
     const fetchModels = async () => {
@@ -104,6 +110,20 @@ export default function DashboardContainers() {
             modelPath: model.value,
             label: `Video: ${model.label}`,
             kind: "video",
+          })
+        }
+      } catch {
+        // silent
+      }
+
+      try {
+        const visionModels = await fetchDeployableVisionModels()
+        for (const model of visionModels) {
+          options.push({
+            id: `vision::${model.value}`,
+            modelPath: model.value,
+            label: `Vision: ${model.label}`,
+            kind: "vision",
           })
         }
       } catch {
@@ -156,6 +176,8 @@ export default function DashboardContainers() {
         await deployAudioModel(option.modelPath)
       } else if (option.kind === "video") {
         await deployVideoModel(option.modelPath)
+      } else if (option.kind === "vision") {
+        await deployVisionModel(option.modelPath)
       } else {
         await deployTextModel(option.modelPath)
       }
@@ -244,6 +266,13 @@ export default function DashboardContainers() {
               onSelect={setSelectedModelId}
               titleMarginTop="xs"
             />
+            <DeployableModelChips
+              title="Vision Models"
+              models={visionModels}
+              selectedId={selectedModelId}
+              onSelect={setSelectedModelId}
+              titleMarginTop="xs"
+            />
           </Stack>
 
           {selectedModelId && (
@@ -322,6 +351,17 @@ export default function DashboardContainers() {
                   models={videoModels}
                   isOpen={videoOpen}
                   onToggle={() => setVideoOpen(o => !o)}
+                  onDeploy={handleDeployById}
+                  deployLoading={deployLoading}
+                />
+              </Box>
+
+              <Box mt="xs">
+                <DeployableModelList
+                  title="Vision Models"
+                  models={visionModels}
+                  isOpen={visionOpen}
+                  onToggle={() => setVisionOpen(o => !o)}
                   onDeploy={handleDeployById}
                   deployLoading={deployLoading}
                 />

--- a/gen-ai-playground/frontend/src/pages/Front.tsx
+++ b/gen-ai-playground/frontend/src/pages/Front.tsx
@@ -37,7 +37,8 @@ const Front = () => {
   const hoverCard3 = useFadeIn(400)
   const hoverCard4 = useFadeIn(500)
   const videoGenCard = useFadeIn(600)
-  const bannerFade = useFadeIn(600)
+  const webcamCard = useFadeIn(700)
+  const bannerFade = useFadeIn(800)
   const carouselFade = useFadeIn(400)
   const { isLoggedIn } = useAuth()
   const navigate = useNavigate()
@@ -197,6 +198,15 @@ const Front = () => {
             cardRef={videoGenCard.ref}
             isVisible={videoGenCard.isVisible}
             onClick={() => handleLoggedIn("VideoGenerator")}
+          />
+          <HoverCard
+            image="/images/text-generate.png"
+            title="Webcam AI Analysis"
+            description="Connect your webcam and use vision-language models to describe the live feed."
+            buttonText="Go to live webcam analysis"
+            cardRef={webcamCard.ref}
+            isVisible={webcamCard.isVisible}
+            onClick={() => handleLoggedIn("WebcamAnalysis")}
           />
         </Group>
       </Box>

--- a/gen-ai-playground/frontend/src/pages/Playground.tsx
+++ b/gen-ai-playground/frontend/src/pages/Playground.tsx
@@ -8,6 +8,7 @@ import ImageEditor from "../components/ImageEditor"
 import TextGenerator from "../components/TextGenerator"
 import Transcribe from "../components/Transcribe"
 import VideoGenerator from "../components/VideoGenerator"
+import WebcamAIAnalysis from "../components/WebcamAIAnalysis"
 import { PLAYGROUND_TABS } from "../constants/tabs"
 import NotFoundPage from "./PageNotFound"
 
@@ -29,6 +30,7 @@ export default function Playground({ historyOpen }: { historyOpen: boolean }) {
     TextGenerator: <TextGenerator opened={historyOpen} />,
     Transcribe: <Transcribe />,
     VideoGenerator: <VideoGenerator />,
+    WebcamAnalysis: <WebcamAIAnalysis opened={historyOpen} />,
   }
 
   // If tab is invalid, redirect to default

--- a/gen-ai-playground/frontend/src/services/dashboardService.ts
+++ b/gen-ai-playground/frontend/src/services/dashboardService.ts
@@ -104,6 +104,16 @@ export async function fetchDeployableVideoModels(): Promise<Array<{ value: strin
   return res.data.available_models ?? []
 }
 
+export async function fetchDeployableVisionModels(): Promise<Array<{ value: string; label: string }>> {
+  const res = await apiClient.get<{ available_models?: Array<{ value: string; label: string }> }>(
+    "/vision/models",
+    {
+      headers: getCsrfHeaders(),
+    },
+  )
+  return res.data.available_models ?? []
+}
+
 export type DashboardContainer = {
   name: string
   status: string
@@ -149,6 +159,16 @@ export async function deployAudioModel(modelPath: string): Promise<void> {
 export async function deployVideoModel(modelPath: string): Promise<void> {
   await apiClient.post(
     "/video/deploy",
+    { model_path: modelPath },
+    {
+      headers: getJsonCsrfHeaders(),
+    },
+  )
+}
+
+export async function deployVisionModel(modelPath: string): Promise<void> {
+  await apiClient.post(
+    "/vision/deploy",
     { model_path: modelPath },
     {
       headers: getJsonCsrfHeaders(),

--- a/gen-ai-playground/frontend/src/services/visionService.ts
+++ b/gen-ai-playground/frontend/src/services/visionService.ts
@@ -1,0 +1,134 @@
+import { getCsrfHeaders, getJsonCsrfHeaders } from "../utils/auth"
+import { apiClient } from "./httpClient"
+
+export type VisionChatMessagePayload = {
+  role: "system" | "user" | "assistant"
+  content: Array<{ type: string; text?: string; image_url?: { url: string } }>
+}
+
+export interface StreamVisionRequest {
+  deployment_name: string
+  model_path?: string
+  messages: VisionChatMessagePayload[]
+  max_tokens?: number
+  temperature?: number
+  top_p?: number
+}
+
+export type VisionModelApiItem = {
+  value: string
+  label: string
+}
+
+export type VisionModelStatuses = Record<string, "live" | "starting" | "offline" | "unknown">
+
+export async function fetchVisionModels(): Promise<VisionModelApiItem[]> {
+  const res = await apiClient.get<{ available_models?: VisionModelApiItem[] }>("/vision/models", {
+    headers: getCsrfHeaders(),
+  })
+  return res.data.available_models ?? []
+}
+
+export async function fetchVisionModelStatuses(): Promise<VisionModelStatuses> {
+  const res = await apiClient.get<VisionModelStatuses>("/vision/model-statuses", {
+    headers: getCsrfHeaders(),
+  })
+  return res.data
+}
+
+export async function streamVision(request: StreamVisionRequest, ref: { current: boolean }): Promise<AsyncIterableIterator<string>> {
+  const authFromAxiosDefaults =
+    (apiClient.defaults.headers?.common as Record<string, unknown> | undefined)?.Authorization ??
+    (apiClient.defaults.headers?.common as Record<string, unknown> | undefined)?.authorization
+
+  const headers: Record<string, string> = {
+    ...getJsonCsrfHeaders(),
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+  }
+  if (typeof authFromAxiosDefaults === "string" && authFromAxiosDefaults.trim()) {
+    headers.Authorization = authFromAxiosDefaults
+  }
+
+  const baseUrl = (apiClient.defaults.baseURL ?? "").replace(/\/+$/, "")
+  const response = await fetch(`${baseUrl}/vision/stream`, {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Stream error: ${response.status} ${response.statusText} - ${errorText}`);
+  }
+
+  if (!response.body) {
+    throw new Error("No response body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  console.log("[VisionService] Stream response received, status:", response.status);
+
+  async function* generate(): AsyncIterableIterator<string> {
+    let rawLineCount = 0;
+    while (ref.current) {
+      const { done, value } = await reader.read();
+      if (done) {
+        console.log(`[VisionService] Reader done, total raw lines: ${rawLineCount}`);
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      // Keep the last (potentially incomplete) line in the buffer
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line) continue;
+        rawLineCount++;
+        if (rawLineCount <= 5) {
+          console.log(`[VisionService] raw line[${rawLineCount}]:`, line.substring(0, 150));
+        }
+        if (!line.startsWith("data: ")) continue;
+        if (line === "data: [DONE]") {
+          console.log("[VisionService] Got [DONE] signal");
+          reader.cancel();
+          return;
+        }
+
+        const dataStr = line.replace("data: ", "").trim();
+        if (!dataStr) continue;
+
+        try {
+          const data = JSON.parse(dataStr);
+          if (data.error) {
+            console.error("[VisionService] Stream error from server:", data.error);
+            throw new Error(data.error);
+          }
+          if (data.choices && data.choices.length > 0) {
+            const delta = data.choices[0]?.delta || {};
+            const content = delta.content || "";
+            const reasoning = delta.reasoning_content || "";
+            if (reasoning || content) {
+              yield reasoning + content;
+            }
+          }
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            // JSON parse failed — incomplete line or malformed chunk, skip
+            console.warn("[VisionService] JSON parse error on line:", dataStr.substring(0, 100));
+            continue;
+          }
+          throw e;
+        }
+      }
+    }
+    reader.cancel();
+  }
+
+  return generate();
+}

--- a/gen-ai-playground/frontend/src/services/visionService.ts
+++ b/gen-ai-playground/frontend/src/services/visionService.ts
@@ -71,8 +71,6 @@ export async function streamVision(request: StreamVisionRequest, ref: { current:
   const decoder = new TextDecoder();
   let buffer = "";
 
-  console.log("[VisionService] Stream response received, status:", response.status);
-
   async function* generate(): AsyncIterableIterator<string> {
     while (ref.current) {
       const { done, value } = await reader.read()

--- a/gen-ai-playground/frontend/src/services/visionService.ts
+++ b/gen-ai-playground/frontend/src/services/visionService.ts
@@ -74,25 +74,17 @@ export async function streamVision(request: StreamVisionRequest, ref: { current:
   console.log("[VisionService] Stream response received, status:", response.status);
 
   async function* generate(): AsyncIterableIterator<string> {
-    let rawLineCount = 0;
     while (ref.current) {
-      const { done, value } = await reader.read();
-      if (done) {
-        console.log(`[VisionService] Reader done, total raw lines: ${rawLineCount}`);
-        break;
-      }
+      const { done, value } = await reader.read()
+      if (done) break
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split("\n")
       // Keep the last (potentially incomplete) line in the buffer
-      buffer = lines.pop() || "";
+      buffer = lines.pop() || ""
 
       for (const line of lines) {
-        if (!line) continue;
-        rawLineCount++;
-        if (rawLineCount <= 5) {
-          console.log(`[VisionService] raw line[${rawLineCount}]:`, line.substring(0, 150));
-        }
+        if (!line) continue
         if (!line.startsWith("data: ")) continue;
         if (line === "data: [DONE]") {
           console.log("[VisionService] Got [DONE] signal");

--- a/gen-ai-playground/frontend/src/services/visionService.ts
+++ b/gen-ai-playground/frontend/src/services/visionService.ts
@@ -85,9 +85,8 @@ export async function streamVision(request: StreamVisionRequest, ref: { current:
         if (!line) continue
         if (!line.startsWith("data: ")) continue;
         if (line === "data: [DONE]") {
-          console.log("[VisionService] Got [DONE] signal");
-          reader.cancel();
-          return;
+          reader.cancel()
+          return
         }
 
         const dataStr = line.replace("data: ", "").trim();

--- a/gen-ai-playground/frontend/src/utils/types.ts
+++ b/gen-ai-playground/frontend/src/utils/types.ts
@@ -8,3 +8,13 @@ export interface DeployOption {
   label: string
   modelPath: string
 }
+
+// ModelStatus represents the lifecycle state of a deployed model as reported by the backend.
+export type ModelStatus = "live" | "starting" | "offline" | "unknown"
+
+export const modelStatusPriority: Record<ModelStatus, number> = {
+  live: 0,
+  starting: 1,
+  unknown: 2,
+  offline: 3,
+}

--- a/gen-ai-playground/tests/authenticated/transcribe.spec.ts
+++ b/gen-ai-playground/tests/authenticated/transcribe.spec.ts
@@ -3,9 +3,9 @@ import { test, expect, Page } from '@playwright/test';
 const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:5173/';
 const TRANSCRIBE_URL = new URL('playground/Transcribe', FRONTEND_URL).toString();
 
-test.use({ storageState: 'playwright/.auth/user.json' });
+import type { ModelStatus } from '../../frontend/src/utils/types';
 
-type ModelStatus = 'live' | 'starting' | 'offline' | 'unknown';
+test.use({ storageState: 'playwright/.auth/user.json' });
 
 function createDeferred() {
   let resolve!: () => void;


### PR DESCRIPTION
This branch adds end-to-end support for vision-language models and a new webcam-based analysis experience.

It introduces a new backend vision router with endpoints to list vision models, report model status, deploy a vision model, and stream chat completions over SSE. Template discovery was extended to recognize vision- templates, the template config schema now supports model_mode: "vision", and a new vision template was added for Qwen3 VL SGLang.

On the frontend, a new Webcam AI Analysis experience was added. It captures live webcam frames, sends them to a deployed vision model, and streams the response back to the UI. The landing page now includes a Webcam AI Analysis card, the playground tab list was extended with a new WebcamAnalysis tab, and the dashboard/deployment UI now surfaces vision models alongside text, audio, and video models. A new frontend vision service handles fetching vision models/statuses and streaming inference responses.