### PR TITLE
 Consolidate VERDA_API_KEY into VERDA_INFERENCE_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ environment:
    # Add other secrets as needed
 ```
 
-> **Important:** Secrets such as `VERDA_API_KEY`, `VERDA_CLIENT_ID`, `VERDA_CLIENT_SECRET`, and `HF_TOKEN` are not included in the default Compose environment section. To use these with Docker Compose, you must either:
+> **Important:** Secrets such as `VERDA_INFERENCE_KEY`, `VERDA_CLIENT_ID`, `VERDA_CLIENT_SECRET`, and `HF_TOKEN` are not included in the default Compose environment section. To use these with Docker Compose, you must either:
 > - Add them directly to the `environment:` section in your Compose file, **or**
 > - Create a `backend/.env.local`
 
 > Example `backend/.env.local` file:
 ```env
 # Verda integration (keep these secret!)
-VERDA_API_KEY="your-verda-api-key"
+VERDA_INFERENCE_KEY="your-verda-inference-key"
 VERDA_CLIENT_ID="your-verda-client-id"
 VERDA_CLIENT_SECRET="your-verda-client-secret"
 
@@ -126,7 +126,7 @@ When running the backend and frontend directly (not in Docker), you can use `.en
 MONGO_DB_URL="mongodb://mongodb:27017"
 
 # Verda integration (keep these secret!)
-VERDA_API_KEY="your-verda-api-key"
+VERDA_INFERENCE_KEY="your-verda-inference-key"
 VERDA_CLIENT_ID="your-verda-client-id"
 VERDA_CLIENT_SECRET="your-verda-client-secret"
 
@@ -188,7 +188,7 @@ npm run dev
 
 4. The application will be available via the route address defined by OpenShift.
 
-5. The required environment variables for the backend (such as ALLOWED_ORIGINS, VERDA_API_KEY, MONGO_DB_URL, INVITATION_CODE, JWT_SECRET_KEY, VERDA_CLIENT_SECRET, VERDA_CLIENT_ID, HF_TOKEN, ADMIN_USERNAME, ADMIN_PASSWORD, and JWT_REFRESH_SECRET_KEY) are defined in the example [gen-ai-playground/manifests/backend/deployment.yaml](gen-ai-playground/manifests/backend/deployment.yaml). Make sure to set these in your OpenShift environment, using secrets where appropriate for sensitive values.
+5. The required environment variables for the backend (such as ALLOWED_ORIGINS, VERDA_INFERENCE_KEY, MONGO_DB_URL, INVITATION_CODE, JWT_SECRET_KEY, VERDA_CLIENT_SECRET, VERDA_CLIENT_ID, HF_TOKEN, ADMIN_USERNAME, ADMIN_PASSWORD, and JWT_REFRESH_SECRET_KEY) are defined in the example [gen-ai-playground/manifests/backend/deployment.yaml](gen-ai-playground/manifests/backend/deployment.yaml). Make sure to set these in your OpenShift environment, using secrets where appropriate for sensitive values.
 
 ---
 

--- a/gen-ai-playground/backend/app/config.py
+++ b/gen-ai-playground/backend/app/config.py
@@ -20,8 +20,7 @@ class Settings:
     
     # External API Keys (Bearer Tokens - NEVER expose to frontend)
     # These are used by backend to authenticate with external inference APIs
-    VERDA_API_KEY: str = os.getenv("VERDA_API_KEY")
-    VERDA_INFERENCE_KEY: str = os.getenv("VERDA_INFERENCE_KEY") or os.getenv("VERDA_API_KEY")
+    VERDA_INFERENCE_KEY: str = os.getenv("VERDA_INFERENCE_KEY")
     
     # Verda SDK credentials (for container deployments)
     VERDA_CLIENT_ID: str = os.getenv("VERDA_CLIENT_ID")

--- a/gen-ai-playground/backend/app/routers/audio.py
+++ b/gen-ai-playground/backend/app/routers/audio.py
@@ -39,7 +39,7 @@ AUDIO_HISTORY_PROJECTION = {
 
 
 def _inference_headers() -> dict[str, str]:
-    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    token = settings.VERDA_INFERENCE_KEY
     if not token:
         return {}
     return {"Authorization": f"Bearer {token}"}

--- a/gen-ai-playground/backend/app/routers/images.py
+++ b/gen-ai-playground/backend/app/routers/images.py
@@ -167,10 +167,10 @@ async def generate_image(
     # Start timing
     start_time = time.perf_counter()
     # Validate API key
-    if not settings.VERDA_API_KEY:
+    if not settings.VERDA_INFERENCE_KEY:
         raise HTTPException(
             status_code=500,
-            detail="VERDA_API_KEY not set in environment."
+            detail="VERDA_INFERENCE_KEY not set in environment."
         )
     
     # Select API URL based on model
@@ -179,7 +179,7 @@ async def generate_image(
     # Prepare request
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {settings.VERDA_API_KEY}"
+        "Authorization": f"Bearer {settings.VERDA_INFERENCE_KEY}"
     }
     parent_image_id = None
     user_base64_image = None
@@ -284,7 +284,7 @@ async def edit_image(
      # Prepare request
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {settings.VERDA_API_KEY}"
+        "Authorization": f"Bearer {settings.VERDA_INFERENCE_KEY}"
     }
 
     data = build_request_data(model, prompt, image_base64)

--- a/gen-ai-playground/backend/app/routers/text.py
+++ b/gen-ai-playground/backend/app/routers/text.py
@@ -58,7 +58,7 @@ manager = ConnectionManager()
 
 
 def _inference_headers() -> dict[str, str]:
-    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    token = settings.VERDA_INFERENCE_KEY
     if not token:
         return {}
     return {"Authorization": f"Bearer {token}"}

--- a/gen-ai-playground/backend/app/routers/video.py
+++ b/gen-ai-playground/backend/app/routers/video.py
@@ -50,7 +50,7 @@ VIDEO_MODEL_ALIASES = {
 
 
 def _inference_headers() -> dict[str, str]:
-    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    token = settings.VERDA_INFERENCE_KEY
     if not token:
         return {}
     return {"Authorization": f"Bearer {token}"}

--- a/gen-ai-playground/backend/app/routers/vision.py
+++ b/gen-ai-playground/backend/app/routers/vision.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/vision", tags=["vision"])
 
 
 def _inference_headers() -> dict[str, str]:
-    token = settings.VERDA_INFERENCE_KEY or settings.VERDA_API_KEY
+    token = settings.VERDA_INFERENCE_KEY
     if not token:
         return {}
     return {"Authorization": f"Bearer {token}"}

--- a/gen-ai-playground/backend/tests/test_audio_helpers.py
+++ b/gen-ai-playground/backend/tests/test_audio_helpers.py
@@ -31,19 +31,12 @@ class _DummyUpload:
 
 
 class TestAudioHelpers:
-    def test_inference_headers_prefers_inference_key(self, monkeypatch):
+    def test_inference_headers_uses_inference_key(self, monkeypatch):
         monkeypatch.setattr(audio_router.settings, "VERDA_INFERENCE_KEY", "inference-key", raising=False)
-        monkeypatch.setattr(audio_router.settings, "VERDA_API_KEY", "api-key", raising=False)
         assert audio_router._inference_headers() == {"Authorization": "Bearer inference-key"}
 
-    def test_inference_headers_uses_api_key_fallback(self, monkeypatch):
+    def test_inference_headers_empty_without_key(self, monkeypatch):
         monkeypatch.setattr(audio_router.settings, "VERDA_INFERENCE_KEY", None, raising=False)
-        monkeypatch.setattr(audio_router.settings, "VERDA_API_KEY", "api-key", raising=False)
-        assert audio_router._inference_headers() == {"Authorization": "Bearer api-key"}
-
-    def test_inference_headers_empty_without_keys(self, monkeypatch):
-        monkeypatch.setattr(audio_router.settings, "VERDA_INFERENCE_KEY", None, raising=False)
-        monkeypatch.setattr(audio_router.settings, "VERDA_API_KEY", None, raising=False)
         assert audio_router._inference_headers() == {}
 
     def test_audio_deployment_names_from_templates(self, monkeypatch):

--- a/gen-ai-playground/backend/tests/test_history.py
+++ b/gen-ai-playground/backend/tests/test_history.py
@@ -353,7 +353,7 @@ class TestGenerateImageWithAuth:
         }
         headers = {"Authorization": f"Bearer {auth_token}"}
         
-        with patch('app.config.settings.VERDA_API_KEY', "test-api-key"):
+        with patch('app.config.settings.VERDA_INFERENCE_KEY', "test-api-key"):
             response = client.post("/images/generate", json=image_request, headers=headers)
         
         assert response.status_code == 200
@@ -388,7 +388,7 @@ class TestGenerateImageWithAuth:
         mock_client_instance.post.return_value = mock_response
         mock_async_client_cls.return_value = mock_client_instance
         
-        with patch('app.config.settings.VERDA_API_KEY', "test-api-key"):
+        with patch('app.config.settings.VERDA_INFERENCE_KEY', "test-api-key"):
             # Generate image for user 1
             headers1 = {"Authorization": f"Bearer {auth_token}"}
             response1 = client.post("/images/generate", 

--- a/gen-ai-playground/docker-compose.yml
+++ b/gen-ai-playground/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - JWT_SECRET_KEY=dev-secret-key-for-local-development
       - JWT_REFRESH_SECRET_KEY=dev-refresh-secret-key-for-local-development
       - INVITATION_CODE=local-invitation-code
-      - VERDA_API_KEY=test-api-key
+      - VERDA_INFERENCE_KEY=test-api-key
     volumes:
       - ./backend:/app
     depends_on:

--- a/gen-ai-playground/manifests/backend/deployment.yaml
+++ b/gen-ai-playground/manifests/backend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               value: "production"
             - name: ALLOWED_ORIGINS
               value: "https://gen-ai-frontend-route-ohtuprojekti-staging.apps.ocp-prod-0.k8s.it.helsinki.fi"
-            - name: VERDA_API_KEY
+            - name: VERDA_INFERENCE_KEY
               valueFrom:
                 secretKeyRef:
                   name: verda-api-secret


### PR DESCRIPTION
  - Drop the `VERDA_API_KEY` setting and its fallback; the backend now reads only `VERDA_INFERENCE_KEY`
  - Update router header helpers, image endpoint, tests, Compose, and the OpenShift manifest to the single env var
  - Deployment manifest keeps `secretKeyRef.key: VERDA_API_KEY` so the `verda-api-secret` Secret needs no change